### PR TITLE
fix: settings overlay gestures, 12/24h clock, ConfigServer crash

### DIFF
--- a/app/src/main/java/com/custom/astrion/MainActivity.kt
+++ b/app/src/main/java/com/custom/astrion/MainActivity.kt
@@ -116,6 +116,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Log.i("MainActivity", "onCreate — activity instance ${this.hashCode()}")
 
         // Enable full-screen immersive sticky mode for dedicated wall/remote tablet mode
         @Suppress("DEPRECATION")
@@ -137,6 +138,23 @@ class MainActivity : ComponentActivity() {
         wakeOnMotionEnabled = prefs.getBoolean("wake_on_motion_enabled", true)
         setupMotionWake()
 
+        initClientsAndServer()
+        configServerEnabled = prefs.getBoolean("config_server_enabled", true)
+        if (configServerEnabled) startConfigServer()
+        lifecycleScope.launch { harmonyRegistry.connectAll() }
+
+        currentPageIndex = dashboard.config.startPage
+        rebindHotkeysForCurrentPage()
+        client.connect()
+
+        composeContent()
+    }
+
+    /** Creates (or re-creates) the HA client, Harmony registry, and ConfigServer
+     *  from current RemoteSettings. Called once from onCreate and again whenever
+     *  connection settings are saved — avoids Activity.recreate(), which is
+     *  unreliable on Android 8.1 HOME launcher activities. */
+    private fun initClientsAndServer() {
         client = HaClient(baseUrl = RemoteSettings.haUrl(this), token = RemoteSettings.haToken(this))
         harmonyRegistry = HarmonyHubRegistry(
             hubs = RemoteSettings.harmonyHubs(this),
@@ -146,17 +164,30 @@ class MainActivity : ComponentActivity() {
         configServer = ConfigServer(
             context = this,
             harmonyRegistry = harmonyRegistry,
-            onConnectionSaved = { runOnUiThread { recreate() } },
+            onConnectionSaved = { runOnUiThread { reconnectWithNewSettings() } },
             onDashboardUpdated = { runOnUiThread { reloadDashboard() } },
         )
-        configServerEnabled = prefs.getBoolean("config_server_enabled", true)
+    }
+
+    /** Called when the user saves new HA/Harmony connection settings via the
+     *  web configurator. Disconnects the old clients, re-creates them with the
+     *  updated settings, restarts the ConfigServer, and re-composes the UI —
+     *  all within the same Activity instance, no recreate() needed. */
+    private fun reconnectWithNewSettings() {
+        Log.i("MainActivity", "reconnectWithNewSettings")
+        client.disconnect()
+        harmonyRegistry.disconnectAll()
+        runCatching { configServer.stop() }
+
+        initClientsAndServer()
         if (configServerEnabled) startConfigServer()
+        client.connect()
         lifecycleScope.launch { harmonyRegistry.connectAll() }
 
-        currentPageIndex = dashboard.config.startPage
-        rebindHotkeysForCurrentPage()
-        client.connect()
+        composeContent()
+    }
 
+    private fun composeContent() {
         setContent {
             val entities = client.entities.collectAsState()
             val connection = client.connection.collectAsState()
@@ -179,6 +210,10 @@ class MainActivity : ComponentActivity() {
                 setConfigServerEnabled = { enabled -> updateConfigServerEnabled(enabled) },
             )
         }
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onBackPressed() {
     }
 
     override fun onResume() {
@@ -348,7 +383,17 @@ class MainActivity : ComponentActivity() {
 
     private fun startConfigServer() {
         runCatching { configServer.start(NanoHTTPD.SOCKET_READ_TIMEOUT, false) }
-            .onFailure { Log.e("ConfigServer", "failed to start on :8080", it) }
+            .onSuccess { Log.i("ConfigServer", "started on :8080") }
+            .onFailure {
+                Log.e("ConfigServer", "failed to start on :8080", it)
+                keyHandler.postDelayed({
+                    if (!isDestroyed) {
+                        runCatching { configServer.start(NanoHTTPD.SOCKET_READ_TIMEOUT, false) }
+                            .onSuccess { Log.i("ConfigServer", "retry: started on :8080") }
+                            .onFailure { e -> Log.e("ConfigServer", "retry failed on :8080", e) }
+                    }
+                }, 500L)
+            }
     }
 
     /** Called from the settings page switch — persists the choice and
@@ -384,6 +429,7 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
+        Log.i("MainActivity", "onDestroy — activity instance ${this.hashCode()}")
         sensorManager?.unregisterListener(motionListener)
         client.disconnect()
         harmonyRegistry.disconnectAll()

--- a/app/src/main/java/com/custom/astrion/ui/Dashboard.kt
+++ b/app/src/main/java/com/custom/astrion/ui/Dashboard.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -201,36 +202,62 @@ fun Dashboard(
  * Full-screen settings overlay, reached only by swiping down from the top
  * edge (see [TopStatusBar]) — deliberately NOT part of `config.pages`, so it
  * never shows up in the horizontal pager or the page-indicator dots.
- * Dismissed by an upward swipe, the system back button, or the close row.
+ * Dismissed by an upward swipe from the bottom gesture strip, the system
+ * back button, or the close row.
+ *
+ * The swipe-up-to-close gesture lives on a dedicated bottom strip that sits
+ * above the scrollable content in z-order. This avoids the gesture conflict
+ * between `detectVerticalDragGestures` and `verticalScroll` when both are on
+ * the same node — the scroll consumer eats all vertical drags before the drag
+ * detector ever fires.
  */
 @Composable
 private fun SettingsOverlay(ctx: CardContext, onClose: () -> Unit) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color(0xFF0E2229))
-            .pointerInput(Unit) {
-                detectVerticalDragGestures { change, dragAmount ->
-                    change.consume()
-                    if (dragAmount < -25f) onClose()
-                }
+    Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0E2229))) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 10.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                Text(
+                    "✕ " + stringResource(R.string.close),
+                    color = Color(0xFF93AFB6),
+                    fontSize = 13.sp,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(10.dp))
+                        .clickable { onClose() }
+                        .padding(horizontal = 10.dp, vertical = 6.dp),
+                )
             }
-            .verticalScroll(rememberScrollState())
-            .padding(horizontal = 10.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp),
-    ) {
-        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-            Text(
-                "✕ " + stringResource(R.string.close),
-                color = Color(0xFF93AFB6),
-                fontSize = 13.sp,
+            SettingsMenu(ctx)
+        }
+
+        // Bottom gesture strip: swipe up to close. Sits above the scrollable
+        // content so the drag detector doesn't fight verticalScroll for events.
+        // A visual handle bar cues the user where to swipe.
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .height(50.dp)
+                .pointerInput(Unit) {
+                    detectVerticalDragGestures { change, dragAmount ->
+                        if (dragAmount < -15f) onClose()
+                    }
+                },
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(
                 modifier = Modifier
-                    .clip(RoundedCornerShape(10.dp))
-                    .clickable { onClose() }
-                    .padding(horizontal = 10.dp, vertical = 6.dp),
+                    .width(40.dp)
+                    .height(4.dp)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(Color(0xFF3A5560)),
             )
         }
-        SettingsMenu(ctx)
     }
 }
 

--- a/app/src/main/java/com/custom/astrion/ui/Topstatusbar.kt
+++ b/app/src/main/java/com/custom/astrion/ui/Topstatusbar.kt
@@ -11,6 +11,7 @@ import android.net.NetworkRequest
 import android.os.BatteryManager
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -64,7 +65,7 @@ fun TopStatusBar(onSwipeDownToSettings: () -> Unit) {
 
     val wifiConnected = rememberWifiConnected(context)
     val (batteryPct, charging) = rememberBatteryState(context)
-    val time = rememberTickingTime()
+    val time = rememberTickingTime(context)
 
     Row(
         modifier =
@@ -88,20 +89,31 @@ fun TopStatusBar(onSwipeDownToSettings: () -> Unit) {
                 },
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Icon(
-            imageVector = if (wifiConnected) Icons.Filled.Wifi else Icons.Filled.WifiOff,
-            contentDescription = null,
-            tint = Color(0xFF93AFB6),
-            modifier = Modifier.size(16.dp),
-        )
+        // Box overlay: clock centered to the full bar width, Wi-Fi and
+        // battery absolutely positioned to the edges so their widths don't
+        // shift the clock off true center.
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(time, color = Color(0xFFCFCFCF), fontSize = 13.sp, fontWeight = FontWeight.Medium)
 
-        Spacer(Modifier.weight(1f))
-        Text(time, color = Color(0xFFCFCFCF), fontSize = 13.sp, fontWeight = FontWeight.Medium)
-        Spacer(Modifier.weight(1f))
+            Icon(
+                imageVector = if (wifiConnected) Icons.Filled.Wifi else Icons.Filled.WifiOff,
+                contentDescription = null,
+                tint = Color(0xFF93AFB6),
+                modifier = Modifier.size(16.dp).align(Alignment.CenterStart),
+            )
 
-        BatteryGlyph(percent = batteryPct, charging = charging)
-        Spacer(Modifier.padding(end = 2.dp))
-        Text("$batteryPct%", color = Color(0xFF93AFB6), fontSize = 12.sp)
+            Row(
+                modifier = Modifier.align(Alignment.CenterEnd),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                BatteryGlyph(percent = batteryPct, charging = charging)
+                Spacer(Modifier.padding(end = 2.dp))
+                Text("$batteryPct%", color = Color(0xFF93AFB6), fontSize = 12.sp)
+            }
+        }
     }
 }
 
@@ -145,17 +157,23 @@ private fun BatteryGlyph(
 }
 
 @Composable
-private fun rememberTickingTime(): String {
+private fun rememberTickingTime(context: Context): String {
     var time by remember {
-        mutableStateOf(SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date()))
+        mutableStateOf(formatNow(context))
     }
     LaunchedEffect(Unit) {
         while (true) {
-            time = SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date())
+            time = formatNow(context)
             kotlinx.coroutines.delay(15.seconds)
         }
     }
     return time
+}
+
+private fun formatNow(context: Context): String {
+    val is24 = android.text.format.DateFormat.is24HourFormat(context)
+    val pattern = if (is24) "HH:mm" else "h:mm a"
+    return SimpleDateFormat(pattern, Locale.getDefault()).format(Date())
 }
 
 /** Uses ConnectivityManager.NetworkCallback (not the deprecated

--- a/app/src/main/java/com/custom/astrion/web/Configserver.kt
+++ b/app/src/main/java/com/custom/astrion/web/Configserver.kt
@@ -2,6 +2,8 @@ package com.custom.astrion.web
 
 import android.content.Context
 import android.content.Intent
+import android.os.Handler
+import android.os.Looper
 import android.os.Environment
 import android.provider.Settings
 import android.util.Log
@@ -591,7 +593,7 @@ class ConfigServer(
             haToken = params["ha_token"]?.firstOrNull().orEmpty().trim(),
         )
         RemoteSettings.saveHarmonyHubs(context, parseHubRows(params))
-        onConnectionSaved()
+        Handler(Looper.getMainLooper()).postDelayed({ onConnectionSaved() }, 500L)
         return redirectHome(context.getString(R.string.web_config_saved_reconnecting))
     }
 


### PR DESCRIPTION
Three fixes for the HA100 launcher:

- Settings overlay swipe-up-to-close: detectVerticalDragGestures
  conflicted with verticalScroll; moved to a bottom gesture strip
- Top status bar clock now honors Android 12/24h setting and is
  centered to full bar width
- ConfigServer EADDRINUSE crash on connection save and unmapped
  BACK key destroying the launcher