### PR TITLE
feat(cards): camera card with live stream, snapshot fallback & tap-to-maximize

### DIFF
--- a/app/src/main/assets/docs/index.html
+++ b/app/src/main/assets/docs/index.html
@@ -296,6 +296,7 @@
         <optgroup label="Advanced (raw options)">
           <option value="clock_weather">Clock &amp; weather (clock_weather)</option>
           <option value="media_player">Media player (media_player)</option>
+          <option value="camera">Camera (camera)</option>
           <option value="speaker_group">Speaker group (speaker_group)</option>
           <option value="monitor">System monitor (monitor)</option>
           <option value="picture_elements">Picture elements (picture_elements)</option>

--- a/app/src/main/assets/docs/js/cards.js
+++ b/app/src/main/assets/docs/js/cards.js
@@ -116,6 +116,30 @@ function updateCardFormInputs() {
     `;
     document.getElementById('optMediaVariant').addEventListener('change', updateMediaTopButtonsVisibility);
     updateMediaTopButtonsVisibility();
+  } else if (type === 'camera') {
+    container.innerHTML = `
+      <label>Name (optional, defaults to the entity's friendly name)</label><input type="text" id="optName" placeholder="e.g., Front Door">
+      <label>Entity ID</label><input type="text" id="optEntityId" placeholder="e.g., camera.front_door">
+      <label>Mode</label>
+      <select id="optCameraMode">
+        <option value="stream">Live stream (MJPEG — real motion)</option>
+        <option value="snapshot">Snapshot only (refresh a still — lowest CPU)</option>
+      </select>
+      <label>Snapshot interval (seconds — snapshot mode, and stream-drop fallback)</label><input type="number" id="optCameraInterval" value="2" min="1" max="60">
+      <label>Aspect ratio (width ÷ height)</label>
+      <select id="optCameraAspect">
+        <option value="1.7778">16:9 (widescreen)</option>
+        <option value="1.3333">4:3 (standard)</option>
+        <option value="1">1:1 (square)</option>
+        <option value="0.75">3:4 (portrait)</option>
+      </select>
+      <label>Fit</label>
+      <select id="optCameraFit">
+        <option value="cover">Cover (fill the card, crop edges)</option>
+        <option value="contain">Contain (show the whole frame, letterbox)</option>
+      </select>
+      <div class="hint">"Live stream" decodes Home Assistant's MJPEG feed for real motion; if it stalls it auto-falls-back to still snapshots, then retries. If a camera feels laggy on the remote, switch that card to "Snapshot only" — no reinstall needed. The preview below pulls one real frame from this device when it's connected to HA.</div>
+    `;
   } else if (type === 'fan') {
     container.innerHTML = `
       <label>Name</label><input type="text" id="optName" placeholder="e.g., Standing Fan">
@@ -630,6 +654,18 @@ function fillCardForm(card) {
     document.getElementById('optMediaVolSet').checked = vCtrls.includes('set');
     document.getElementById('optMediaTopButtons').value = JSON.stringify(o.top_buttons || [], null, 2);
     updateMediaTopButtonsVisibility();
+  } else if (type === 'camera') {
+    document.getElementById('optName').value = o.name || '';
+    document.getElementById('optEntityId').value = o.entity_id || '';
+    document.getElementById('optCameraMode').value = o.mode === 'snapshot' ? 'snapshot' : 'stream';
+    document.getElementById('optCameraInterval').value = o.snapshot_interval ?? 2;
+    // Snap the aspect dropdown to the stored value when it matches a preset;
+    // an unusual custom aspect just shows the default here (the JSON keeps its
+    // own value until the card is re-saved from this form).
+    const aspSel = document.getElementById('optCameraAspect');
+    aspSel.value = (o.aspect != null) ? String(o.aspect) : '1.7778';
+    if (!aspSel.value) aspSel.value = '1.7778';
+    document.getElementById('optCameraFit').value = o.fit === 'contain' ? 'contain' : 'cover';
   } else if (type === 'fan') {
     document.getElementById('optName').value = o.name || '';
     document.getElementById('optEntityId').value = o.entity_id || '';
@@ -795,6 +831,16 @@ function addCardToPage() {
         return;
       }
     }
+  } else if (type === 'camera') {
+    const camName = document.getElementById('optName').value.trim();
+    if (camName) newCard.options.name = camName;
+    newCard.options.entity_id = document.getElementById('optEntityId').value || 'camera.entity';
+    if (document.getElementById('optCameraMode').value === 'snapshot') newCard.options.mode = 'snapshot';
+    const camInterval = parseInt(document.getElementById('optCameraInterval').value, 10);
+    if (Number.isFinite(camInterval) && camInterval !== 2) newCard.options.snapshot_interval = camInterval;
+    const camAspect = parseFloat(document.getElementById('optCameraAspect').value);
+    if (Number.isFinite(camAspect) && Math.abs(camAspect - 1.7778) > 0.001) newCard.options.aspect = camAspect;
+    if (document.getElementById('optCameraFit').value === 'contain') newCard.options.fit = 'contain';
   } else if (type === 'fan') {
     newCard.options.name = document.getElementById('optName').value || 'Fan';
     newCard.options.entity_id = document.getElementById('optEntityId').value || 'fan.entity';

--- a/app/src/main/assets/docs/js/mocks.js
+++ b/app/src/main/assets/docs/js/mocks.js
@@ -36,6 +36,8 @@ const MDI = {
   swingOff: 'M13,8.1V6.1C18.3,6.6 20,11.4 20,14H23L20.1,16.9L17.2,14H18C18,11.9 16.4,8.6 13,8.1M7.8,7.1L2.4,1.7L1.1,3L6.3,8.2C4.7,10 4,12.4 4,14H1L5,18L9,14H6C6,12.7 6.6,11 7.9,9.7L20.9,22.7L22.2,21.4L9.3,8.7L7.8,7.1M11,6.1L9.5,6.4L11,7.8V6.1Z',
   swingOn: 'M17.45,17.55L12,23L6.55,17.55L7.96,16.14L11,19.17V4.83L7.96,7.86L6.55,6.45L12,1L17.45,6.45L16.04,7.86L13,4.83V19.17L16.04,16.14L17.45,17.55Z',
   waterPercent: 'M12,3.25C12,3.25 6,10 6,14C6,17.32 8.69,20 12,20A6,6 0 0,0 18,14C18,10 12,3.25 12,3.25M14.47,9.97L15.53,11.03L9.53,17.03L8.47,15.97M9.75,10A1.25,1.25 0 0,1 11,11.25A1.25,1.25 0 0,1 9.75,12.5A1.25,1.25 0 0,1 8.5,11.25A1.25,1.25 0 0,1 9.75,10M14.25,14.5A1.25,1.25 0 0,1 15.5,15.75A1.25,1.25 0 0,1 14.25,17A1.25,1.25 0 0,1 13,15.75A1.25,1.25 0 0,1 14.25,14.5Z',
+  video: 'M17,10.5V7A1,1 0 0,0 16,6H4A1,1 0 0,0 3,7V17A1,1 0 0,0 4,18H16A1,1 0 0,0 17,17V13.5L21,17.5V6.5L17,10.5Z',
+  videoOff: 'M3.27,2L2,3.27L4.73,6H4A1,1 0 0,0 3,7V17A1,1 0 0,0 4,18H16A1,1 0 0,0 16.73,17.73L19.73,20.73L21,19.46M21,6.5L17,10.5V7A1,1 0 0,0 16,6H9.82L21,17.18V6.5Z',
 };
 function mdiSvg(path) { return `<svg viewBox="0 0 24 24" fill="currentColor"><path d="${path}"/></svg>`; }
 
@@ -276,6 +278,16 @@ const MEDIA_MOCK = {
   media_duration: 183,
   shuffle: false,
   repeat: 'off',
+};
+
+const CAMERA_MOCK = {
+  friendly_name: 'Front Door',
+  state: 'streaming', // idle | streaming
+  // entity_picture normally looks like /api/camera_proxy/camera.x?token=…; the
+  // static editor can't reach it, so the preview only uses this to know the
+  // entity is a camera. On a real device the preview fetches a live frame from
+  // /camera-snapshot instead.
+  entity_picture: null,
 };
 
 // Mirrors MediaPlayerCard.kt's Feature bitmask check (EntityState.supports).

--- a/app/src/main/assets/docs/js/preview.js
+++ b/app/src/main/assets/docs/js/preview.js
@@ -702,6 +702,32 @@ function renderPreview() {
           <div class="card-title"><span>${card.type} (${items.length} items)</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
           ${gridHtml}
         </div>`;
+    } else if (card.type === 'camera') {
+      const o = card.options || {};
+      const title = o.name || haFriendlyName(o.entity_id) || prettyEntityName(o.entity_id) || 'Camera';
+      const aspect = (o.aspect != null && Number(o.aspect) > 0) ? Number(o.aspect) : (16 / 9);
+      const fit = o.fit === 'contain' ? 'contain' : 'cover';
+      const mode = o.mode === 'snapshot' ? 'snapshot' : 'stream';
+      const paddingPct = (100 / aspect).toFixed(3);
+      // Only try to pull a real frame when the editor is served by the device
+      // itself (it has the HA token to proxy /camera-snapshot). On GitHub Pages
+      // / offline this stays a placeholder, like the other cards' live data.
+      const canFetch = (typeof deviceModeAvailable !== 'undefined' && deviceModeAvailable) && !!o.entity_id;
+      const snapUrl = canFetch ? `/camera-snapshot?entity=${encodeURIComponent(o.entity_id)}&_=${Date.now()}` : '';
+      const placeholder = `<div style="position:absolute; inset:0; display:flex; align-items:center; justify-content:center; color:#9FB6BD;"><div style="width:44px; height:44px;">${mdiSvg(MDI.video)}</div></div>`;
+      const imgHtml = snapUrl
+        ? `<img src="${snapUrl}" alt="${title}" style="position:absolute; inset:0; width:100%; height:100%; object-fit:${fit};" onerror="this.style.display='none'">`
+        : '';
+      cardEl.innerHTML = `
+        <div class="card">
+          <div class="card-title"><span>camera (${mode})</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
+          <div style="position:relative; width:100%; padding-top:${paddingPct}%; border-radius:14px; overflow:hidden; background:#0E1116;">
+            ${placeholder}
+            ${imgHtml}
+            <div style="position:absolute; left:0; right:0; bottom:0; padding:8px 12px; background:linear-gradient(to top, rgba(0,0,0,.75), transparent); color:#fff; font-weight:600; font-size:13px;">${title}</div>
+          </div>
+          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'camera.entity'} · ${canFetch ? 'live frame from this device' : "placeholder here — a real still shows when opened from your device's /builder/"} · on the remote: ${mode === 'stream' ? 'live MJPEG stream (auto-falls-back to stills)' : 'still snapshot refresh'}</div>
+        </div>`;
     } else {
       cardEl.className = 'card';
       cardEl.innerHTML = `

--- a/app/src/main/java/com/custom/astrion/AstrionApp.kt
+++ b/app/src/main/java/com/custom/astrion/AstrionApp.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.custom.astrion.cards.CardRegistry
 import com.custom.astrion.cards.impl.AppleTvRemoteCard
 import com.custom.astrion.cards.impl.ButtonGridCard
+import com.custom.astrion.cards.impl.CameraCard
 import com.custom.astrion.cards.impl.ClimateCard
 import com.custom.astrion.cards.impl.ClockWeatherCard
 import com.custom.astrion.cards.impl.CoverCard
@@ -43,6 +44,7 @@ class AstrionApp : Application() {
         CardRegistry.register(
             AppleTvRemoteCard(),
             ButtonGridCard(),
+            CameraCard(),
             ClimateCard(),
             ClockWeatherCard(),
             CoverCard(),

--- a/app/src/main/java/com/custom/astrion/cards/impl/CameraCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/CameraCard.kt
@@ -1,0 +1,441 @@
+package com.custom.astrion.cards.impl
+
+import android.graphics.BitmapFactory
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import com.custom.astrion.cards.CardConfig
+import com.custom.astrion.cards.CardContext
+import com.custom.astrion.cards.CardRenderer
+import com.custom.astrion.ui.icons.MdiIcons
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.job
+import kotlinx.coroutines.withContext
+import okhttp3.Response
+import java.io.BufferedInputStream
+import java.io.ByteArrayOutputStream
+import kotlin.coroutines.coroutineContext
+import kotlin.math.max
+
+/**
+ * Live camera card.
+ *
+ * Renders a Home Assistant `camera.*` entity as a live picture. Two modes,
+ * chosen with the `mode` option (default `stream`):
+ *
+ *  - `stream`   — pulls HA's MJPEG feed (`/api/camera_proxy_stream/…`) and
+ *                 decodes each JPEG frame as it arrives, giving real motion.
+ *                 If the stream can't start or drops, it falls back to periodic
+ *                 still snapshots for a few cycles, then retries the stream.
+ *  - `snapshot` — just re-fetches a single still (`entity_picture`) every
+ *                 `snapshot_interval` seconds. Lowest CPU; good for a weak SoC
+ *                 or a camera whose live stream is too laggy.
+ *
+ * Both the stream URL and the still are derived from the entity's live
+ * `entity_picture` attribute (which already carries the rotating access token),
+ * read fresh via [rememberUpdatedState] so token rotation never tears the
+ * stream down.
+ *
+ * Options:
+ *   - `entity_id`         (required) e.g. `camera.front_door`
+ *   - `name`              optional label (defaults to the friendly name)
+ *   - `mode`              `stream` (default) | `snapshot`
+ *   - `snapshot_interval` seconds between stills in snapshot mode / fallback (default 2)
+ *   - `aspect`            width/height ratio of the card (default 1.777 = 16:9)
+ *   - `fit`               `cover` (default, fills & crops) | `contain` (letterboxed)
+ *
+ * Tap the card to open a fullscreen viewer. In the viewer, pinch to zoom
+ * (1x–8x) and drag to pan; the hardware BACK key or the on-screen close
+ * button dismisses it. The live stream keeps flowing while the viewer is
+ * open, so the zoomed view stays live.
+ */
+class CameraCard : CardRenderer {
+    override val type = "camera"
+
+    private companion object {
+        const val PROXY = "/api/camera_proxy/"
+        const val PROXY_STREAM = "/api/camera_proxy_stream/"
+        const val DEFAULT_INTERVAL_S = 2
+        const val FALLBACK_POLLS = 5 // snapshot cycles after a stream drop before retrying the stream
+        const val MAX_JPEG_BYTES = 6 * 1024 * 1024 // guard against a corrupt stream with no EOI marker
+    }
+
+    @Composable
+    override fun Render(
+        config: CardConfig,
+        ctx: CardContext,
+    ) {
+        val entityId = config.string("entity_id")
+        val mode = if (config.string("mode") == "snapshot") "snapshot" else "stream"
+        val intervalMs = (config.int("snapshot_interval", DEFAULT_INTERVAL_S).coerceAtLeast(1)) * 1000L
+        val aspect = ((config.options["aspect"] as? Number)?.toFloat() ?: (16f / 9f)).coerceAtLeast(0.2f)
+        val contentScale = if (config.string("fit") == "contain") ContentScale.Fit else ContentScale.Crop
+
+        val entity = entityId?.let { ctx.entities[it] }
+        val label = config.string("name") ?: entity?.friendlyName ?: entityId ?: "Camera"
+        val entityPicture = entity?.attrString("entity_picture")
+        val currentPicture = rememberUpdatedState(entityPicture)
+
+        var frame by remember(entityId, mode) { mutableStateOf<ImageBitmap?>(null) }
+        var error by remember(entityId, mode) { mutableStateOf(false) }
+        var live by remember(entityId, mode) { mutableStateOf(false) }
+        var showMaximized by remember { mutableStateOf(false) }
+
+        LaunchedEffect(entityId, mode) {
+            if (entityId.isNullOrBlank()) {
+                error = true
+                return@LaunchedEffect
+            }
+
+            // A blocking input.read() on a silent MJPEG stream won't notice
+            // coroutine cancellation on its own, so when this effect is disposed
+            // (card scrolled off / entity or mode changed) we close the live
+            // response from here — that makes the blocked read throw and unwind
+            // promptly instead of leaking a thread + socket.
+            val liveResponse = arrayOfNulls<Response>(1)
+            coroutineContext.job.invokeOnCompletion { runCatching { liveResponse[0]?.close() } }
+
+            suspend fun pollSnapshot() {
+                val pic = currentPicture.value
+                if (pic.isNullOrBlank()) {
+                    if (frame == null) error = true
+                    return
+                }
+                val bmp = ctx.client.fetchBitmap(pic)
+                if (bmp != null) {
+                    frame = bmp
+                    error = false
+                } else if (frame == null) {
+                    error = true
+                }
+            }
+
+            while (isActive) {
+                if (mode == "snapshot") {
+                    live = false
+                    pollSnapshot()
+                    delay(intervalMs)
+                    continue
+                }
+
+                // stream mode ------------------------------------------------
+                val pic = currentPicture.value
+                if (pic.isNullOrBlank()) {
+                    if (frame == null) error = true
+                    delay(1500)
+                    continue
+                }
+                val streamPath =
+                    if (pic.contains(PROXY)) pic.replace(PROXY, PROXY_STREAM) else pic
+
+                val streamed =
+                    runCatching {
+                        val resp = withContext(Dispatchers.IO) { ctx.client.openStream(streamPath) }
+                            ?: return@runCatching false
+                        liveResponse[0] = resp
+                        try {
+                            resp.use { r ->
+                                if (!r.isSuccessful || r.body == null) return@runCatching false
+                                readMjpeg(r) { bmp ->
+                                    frame = bmp
+                                    error = false
+                                    live = true
+                                }
+                            }
+                        } finally {
+                            liveResponse[0] = null
+                        }
+                        true
+                    }.getOrDefault(false)
+
+                live = false
+                if (!isActive) break
+
+                // Stream ended or never started — keep the picture fresh with a
+                // few still polls, then loop back up and retry the live stream.
+                if (!streamed && frame == null) pollSnapshot()
+                repeat(FALLBACK_POLLS) {
+                    if (!isActive) return@LaunchedEffect
+                    pollSnapshot()
+                    delay(intervalMs)
+                }
+            }
+        }
+
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(aspect)
+                    .clip(RoundedCornerShape(18.dp))
+                    .background(Color(0xFF0E1116))
+                    .pointerInput(entityId) {
+                        detectTapGestures(onTap = { showMaximized = true })
+                    },
+        ) {
+            val img = frame
+            if (img != null) {
+                Image(
+                    bitmap = img,
+                    contentDescription = label,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = contentScale,
+                )
+            } else {
+                // No frame yet: connecting spinner-free placeholder, or an error glyph.
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector = if (error) MdiIcons.VideoOff else MdiIcons.Video,
+                        contentDescription = null,
+                        tint = if (error) Color(0xFF6E828A) else Color(0xFF9FB6BD),
+                        modifier = Modifier.size(40.dp),
+                    )
+                }
+            }
+
+            // Bottom gradient + name (and a live dot while a stream is flowing).
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .align(Alignment.BottomStart)
+                        .background(
+                            Brush.verticalGradient(
+                                listOf(Color.Transparent, Color(0xC0000000)),
+                            ),
+                        )
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (live) {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .size(8.dp)
+                                    .clip(CircleShape)
+                                    .background(Color(0xFFE5484D)),
+                        )
+                    }
+                    Text(
+                        text = if (error && frame == null) "$label · unavailable" else label,
+                        color = Color.White,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier =
+                            Modifier
+                                .padding(start = if (live) 7.dp else 0.dp)
+                                .weight(1f, fill = false),
+                    )
+                }
+            }
+        }
+
+        if (showMaximized) {
+            Dialog(
+                onDismissRequest = { showMaximized = false },
+                properties = androidx.compose.ui.window.DialogProperties(usePlatformDefaultWidth = false),
+            ) {
+                BoxWithConstraints(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .background(Color.Black),
+                ) {
+                    val containerW = constraints.maxWidth.toFloat()
+                    val containerH = constraints.maxHeight.toFloat()
+
+                    var scale by remember { mutableFloatStateOf(1f) }
+                    var offsetX by remember { mutableFloatStateOf(0f) }
+                    var offsetY by remember { mutableFloatStateOf(0f) }
+
+                    val img = frame
+                    if (img != null && containerW > 0f && containerH > 0f) {
+                        // Displayed bitmap size at scale 1 under ContentScale.Fit.
+                        val imgAspect = img.width.toFloat() / img.height.toFloat()
+                        val containerAspect = containerW / containerH
+                        val baseW: Float
+                        val baseH: Float
+                        if (imgAspect > containerAspect) {
+                            baseW = containerW
+                            baseH = containerW / imgAspect
+                        } else {
+                            baseH = containerH
+                            baseW = containerH * imgAspect
+                        }
+                        val zoomedW = baseW * scale
+                        val zoomedH = baseH * scale
+                        // Allow panning only while the zoomed image exceeds the
+                        // viewport on that axis; clamp so an edge can't leave the
+                        // screen (the image always covers the viewport when zoomed).
+                        val maxPanX = max(0f, (zoomedW - containerW) / 2f)
+                        val maxPanY = max(0f, (zoomedH - containerH) / 2f)
+                        val clampedX = if (maxPanX > 0f) offsetX.coerceIn(-maxPanX, maxPanX) else 0f
+                        val clampedY = if (maxPanY > 0f) offsetY.coerceIn(-maxPanY, maxPanY) else 0f
+
+                        Image(
+                            bitmap = img,
+                            contentDescription = label,
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .graphicsLayer(
+                                        scaleX = scale,
+                                        scaleY = scale,
+                                        translationX = clampedX,
+                                        translationY = clampedY,
+                                    ),
+                            contentScale = ContentScale.Fit,
+                        )
+                    }
+
+                    // Pinch-to-zoom + pan. Declared before the close button so
+                    // the button (a later sibling) sits above it in the z-order
+                    // and receives taps meant for it.
+                    Box(
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .pointerInput(Unit) {
+                                    detectTransformGestures { _, pan, zoom, _ ->
+                                        val newScale = (scale * zoom).coerceIn(1f, 8f)
+                                        scale = newScale
+                                        if (newScale > 1f) {
+                                            offsetX += pan.x
+                                            offsetY += pan.y
+                                        } else {
+                                            offsetX = 0f
+                                            offsetY = 0f
+                                        }
+                                    }
+                                },
+                    )
+
+                    // Close button — always reachable regardless of zoom state.
+                    Box(
+                        modifier =
+                            Modifier
+                                .align(Alignment.TopEnd)
+                                .padding(12.dp)
+                                .size(40.dp)
+                                .clip(CircleShape)
+                                .background(Color.Black.copy(alpha = 0.5f))
+                                .pointerInput(Unit) {
+                                    detectTapGestures { showMaximized = false }
+                                },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Close,
+                            contentDescription = "Close",
+                            tint = Color.White,
+                            modifier = Modifier.size(22.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Reads a `multipart/x-mixed-replace` MJPEG body and hands each complete
+     * JPEG frame to [onFrame] (on the main thread). Frames are located by
+     * scanning for JPEG SOI (`FF D8`) / EOI (`FF D9`) markers rather than
+     * parsing the multipart boundary headers — simpler and boundary-agnostic.
+     * Decoding happens on the IO dispatcher; only the tiny state write hops to
+     * Main. Returns when the stream ends or the coroutine is cancelled.
+     */
+    private suspend fun readMjpeg(
+        resp: Response,
+        onFrame: (ImageBitmap) -> Unit,
+    ) {
+        withContext(Dispatchers.IO) {
+            val input = BufferedInputStream(resp.body!!.byteStream(), 64 * 1024)
+            val jpeg = ByteArrayOutputStream(96 * 1024)
+            val chunk = ByteArray(16 * 1024)
+            var prev = -1
+            var inFrame = false
+
+            while (coroutineContext.isActive) {
+                val n = input.read(chunk)
+                if (n < 0) break
+                var i = 0
+                while (i < n) {
+                    val b = chunk[i].toInt() and 0xFF
+                    if (inFrame) {
+                        jpeg.write(b)
+                        if (prev == 0xFF && b == 0xD9) {
+                            val bytes = jpeg.toByteArray()
+                            jpeg.reset()
+                            inFrame = false
+                            val bmp =
+                                try {
+                                    BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                                } catch (e: Exception) {
+                                    null
+                                }
+                            if (bmp != null) withContext(Dispatchers.Main) { onFrame(bmp.asImageBitmap()) }
+                        }
+                    } else if (prev == 0xFF && b == 0xD8) {
+                        inFrame = true
+                        jpeg.reset()
+                        jpeg.write(0xFF)
+                        jpeg.write(0xD8)
+                    }
+                    prev = b
+                    i++
+                }
+                if (jpeg.size() > MAX_JPEG_BYTES) {
+                    jpeg.reset()
+                    inFrame = false
+                    prev = -1
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/custom/astrion/ha/HaClient.kt
+++ b/app/src/main/java/com/custom/astrion/ha/HaClient.kt
@@ -91,6 +91,16 @@ class HaClient(
             .callTimeout(10, TimeUnit.SECONDS)
             .build()
 
+    // Client for long-lived streaming GETs (MJPEG camera_proxy_stream): no call
+    // or read timeout so the never-ending multipart response isn't torn down,
+    // but a real connect timeout so a dead HA doesn't hang the reader forever.
+    private val streamHttp =
+        OkHttpClient.Builder()
+            .connectTimeout(8, TimeUnit.SECONDS)
+            .readTimeout(0, TimeUnit.MILLISECONDS)
+            .callTimeout(0, TimeUnit.MILLISECONDS)
+            .build()
+
     private var socket: WebSocket? = null
     private var heartbeatJob: Job? = null
 
@@ -183,6 +193,47 @@ class HaClient(
                 null
             }
         }
+
+    /**
+     * Fetch a URL/HA-relative path as raw bytes, with the bearer token attached.
+     * Same auth/one-shot semantics as [fetchBitmap] but returns the undecoded
+     * body — used to proxy a single camera frame through the config server so
+     * the editor preview can show a real still without the HA token.
+     */
+    suspend fun fetchBytes(path: String): ByteArray? =
+        withContext(Dispatchers.IO) {
+            try {
+                val url = if (path.startsWith("http")) path else baseUrl.trimEnd('/') + path
+                val req = Request.Builder().url(url).header("Authorization", "Bearer $token").build()
+                imageHttp.newCall(req).execute().use { resp ->
+                    if (!resp.isSuccessful) return@withContext null
+                    resp.body?.bytes()
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "fetchBytes failed for $path", e)
+                null
+            }
+        }
+
+    /**
+     * Open an authenticated streaming GET (e.g. HA's MJPEG
+     * `/api/camera_proxy_stream/<entity>?token=…`). Returns the raw OkHttp
+     * [Response]; the caller OWNS it and MUST close it (use `resp.use { … }`)
+     * to release the connection. Uses the no-timeout [streamHttp] client so the
+     * never-ending multipart body isn't cut off. Blocking network call — invoke
+     * off the main thread. Returns null if the request can't even be dispatched.
+     */
+    fun openStream(path: String): Response? {
+        if (baseUrl.isBlank()) return null
+        return try {
+            val url = if (path.startsWith("http")) path else baseUrl.trimEnd('/') + path
+            val req = Request.Builder().url(url).header("Authorization", "Bearer $token").build()
+            streamHttp.newCall(req).execute()
+        } catch (e: Exception) {
+            Log.w(TAG, "openStream failed for $path", e)
+            null
+        }
+    }
 
     /**
      * Browse a media_player's library via the standard `media_player/browse_media`

--- a/app/src/main/java/com/custom/astrion/ui/icons/MdiIcons.kt
+++ b/app/src/main/java/com/custom/astrion/ui/icons/MdiIcons.kt
@@ -338,6 +338,26 @@ object MdiIcons {
         )
     }
 
+    /** Video-camera glyph — [CameraCard]'s placeholder/loading avatar. */
+    val Video: ImageVector by lazy {
+        mdi(
+            "mdi_video",
+            "M17,10.5V7A1,1 0 0,0 16,6H4A1,1 0 0,0 3,7V17A1,1 0 0,0 4,18H16A1,1 0 0,0 17,17V13.5L21,17.5V6.5L17,10.5Z",
+        )
+    }
+
+    /**
+     * Video-camera glyph, slashed — [CameraCard]'s avatar when the camera is
+     * unavailable / no frame could be fetched.
+     */
+    val VideoOff: ImageVector by lazy {
+        mdi(
+            "mdi_video_off",
+            "M3.27,2L2,3.27L4.73,6H4A1,1 0 0,0 3,7V17A1,1 0 0,0 4,18H16A1,1 0 0,0 16.73,17.73L19.73,20.73L21," +
+                "19.46M21,6.5L17,10.5V7A1,1 0 0,0 16,6H9.82L21,17.18V6.5Z",
+        )
+    }
+
     private fun mdi(
         name: String,
         pathData: String,

--- a/app/src/main/java/com/custom/astrion/web/Configserver.kt
+++ b/app/src/main/java/com/custom/astrion/web/Configserver.kt
@@ -19,8 +19,11 @@ import com.custom.astrion.harmony.HarmonyHubRegistry
 import com.custom.astrion.update.UpdateChecker
 import fi.iki.elonen.NanoHTTPD
 import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import org.json.JSONArray
 import org.json.JSONObject
+import java.io.ByteArrayInputStream
 import java.io.File
 import java.util.UUID
 
@@ -44,6 +47,10 @@ import java.util.UUID
  *                        in the dashboard editor's hotkey form
  *  GET  /harmony-discover resolve a hub's numeric hubId from its IP alone
  *                        (?ip=<address>) — used by the "Auto-detect ID" button
+ *  GET  /camera-snapshot proxy a single still frame for a camera.* entity
+ *                        (?entity=<id>) through this device's HA token, as
+ *                        image/jpeg — lets the editor preview show a real
+ *                        camera frame (the browser has no HA token of its own)
  *  GET  /dashboard.json  download the current dashboard.json (backup)
  *  POST /dashboard.json  replace dashboard.json, then live-reload the dashboard
  *  POST /icons           upload a PNG into /sdcard/astrion/icons/
@@ -144,6 +151,7 @@ class ConfigServer(
                 "/harmony-config" -> if (method == Method.GET) serveHarmonyConfig(session) else methodNotAllowed()
                 "/harmony-hubs" -> if (method == Method.GET) serveHarmonyHubs() else methodNotAllowed()
                 "/harmony-discover" -> if (method == Method.GET) serveHarmonyDiscover(session) else methodNotAllowed()
+                "/camera-snapshot" -> if (method == Method.GET) serveCameraSnapshot(session) else methodNotAllowed()
                 "/icons-list" -> if (method == Method.GET) serveIconsList() else methodNotAllowed()
                 "/check-update" -> if (method == Method.GET) handleCheckUpdate() else methodNotAllowed()
                 "/save-connection" -> if (method == Method.POST) handleSaveConnection(session) else methodNotAllowed()
@@ -808,6 +816,53 @@ class ConfigServer(
         }
         onStopActivity(room)
         return newFixedLengthResponse(Response.Status.OK, "application/json", """{"status":"ok","room":"$room"}""")
+    }
+
+    /**
+     * Proxies a single still frame for a `camera.*` entity through this device's
+     * stored HA token, returned as image/jpeg. The dashboard editor's camera
+     * preview points an <img> at `/camera-snapshot?entity=camera.foo`; the
+     * browser can't reach HA's token-authenticated camera_proxy endpoint itself,
+     * so the app fetches it here. `no-store` so the preview shows a fresh frame
+     * each time it's re-rendered.
+     */
+    private fun serveCameraSnapshot(session: IHTTPSession): Response {
+        val entity = session.parameters["entity"]?.firstOrNull()?.trim().orEmpty()
+        if (entity.isBlank()) {
+            return newFixedLengthResponse(Response.Status.BAD_REQUEST, "text/plain", "Missing entity")
+        }
+        val haUrl = RemoteSettings.haUrl(context)
+        val haToken = RemoteSettings.haToken(context)
+        if (haUrl.isBlank() || haToken.isBlank()) {
+            return newFixedLengthResponse(Response.Status.SERVICE_UNAVAILABLE, "text/plain", "HA not configured")
+        }
+        // The browser has no HA token of its own, so the app fetches the
+        // token-authenticated camera_proxy frame here and re-serves it.
+        val path = if (entity.startsWith("camera.")) "/api/camera_proxy/$entity" else null
+        if (path == null) {
+            return newFixedLengthResponse(Response.Status.NOT_FOUND, "text/plain", "Not a camera entity: $entity")
+        }
+        val req =
+            Request.Builder()
+                .url(haUrl.trimEnd('/') + path)
+                .header("Authorization", "Bearer $haToken")
+                .build()
+        val bytes =
+            try {
+                OkHttpClient().newCall(req).execute().use { resp ->
+                    if (!resp.isSuccessful) return newFixedLengthResponse(Response.Status.INTERNAL_ERROR, "text/plain", "HA returned ${resp.code}")
+                    resp.body?.bytes()
+                }
+            } catch (e: Exception) {
+                return newFixedLengthResponse(Response.Status.INTERNAL_ERROR, "text/plain", "Fetch failed: ${e.message}")
+            }
+        if (bytes == null) {
+            return newFixedLengthResponse(Response.Status.INTERNAL_ERROR, "text/plain", "Empty response from HA")
+        }
+        val resp =
+            newFixedLengthResponse(Response.Status.OK, "image/jpeg", ByteArrayInputStream(bytes), bytes.size.toLong())
+        resp.addHeader("Cache-Control", "no-store")
+        return resp
     }
 
     // ---- actions --------------------------------------------------------------

--- a/docs/index.html
+++ b/docs/index.html
@@ -296,6 +296,7 @@
         <optgroup label="Advanced (raw options)">
           <option value="clock_weather">Clock &amp; weather (clock_weather)</option>
           <option value="media_player">Media player (media_player)</option>
+          <option value="camera">Camera (camera)</option>
           <option value="speaker_group">Speaker group (speaker_group)</option>
           <option value="monitor">System monitor (monitor)</option>
           <option value="picture_elements">Picture elements (picture_elements)</option>

--- a/docs/js/cards.js
+++ b/docs/js/cards.js
@@ -116,6 +116,30 @@ function updateCardFormInputs() {
     `;
     document.getElementById('optMediaVariant').addEventListener('change', updateMediaTopButtonsVisibility);
     updateMediaTopButtonsVisibility();
+  } else if (type === 'camera') {
+    container.innerHTML = `
+      <label>Name (optional, defaults to the entity's friendly name)</label><input type="text" id="optName" placeholder="e.g., Front Door">
+      <label>Entity ID</label><input type="text" id="optEntityId" placeholder="e.g., camera.front_door">
+      <label>Mode</label>
+      <select id="optCameraMode">
+        <option value="stream">Live stream (MJPEG — real motion)</option>
+        <option value="snapshot">Snapshot only (refresh a still — lowest CPU)</option>
+      </select>
+      <label>Snapshot interval (seconds — snapshot mode, and stream-drop fallback)</label><input type="number" id="optCameraInterval" value="2" min="1" max="60">
+      <label>Aspect ratio (width ÷ height)</label>
+      <select id="optCameraAspect">
+        <option value="1.7778">16:9 (widescreen)</option>
+        <option value="1.3333">4:3 (standard)</option>
+        <option value="1">1:1 (square)</option>
+        <option value="0.75">3:4 (portrait)</option>
+      </select>
+      <label>Fit</label>
+      <select id="optCameraFit">
+        <option value="cover">Cover (fill the card, crop edges)</option>
+        <option value="contain">Contain (show the whole frame, letterbox)</option>
+      </select>
+      <div class="hint">"Live stream" decodes Home Assistant's MJPEG feed for real motion; if it stalls it auto-falls-back to still snapshots, then retries. If a camera feels laggy on the remote, switch that card to "Snapshot only" — no reinstall needed. The preview below pulls one real frame from this device when it's connected to HA.</div>
+    `;
   } else if (type === 'fan') {
     container.innerHTML = `
       <label>Name</label><input type="text" id="optName" placeholder="e.g., Standing Fan">
@@ -630,6 +654,18 @@ function fillCardForm(card) {
     document.getElementById('optMediaVolSet').checked = vCtrls.includes('set');
     document.getElementById('optMediaTopButtons').value = JSON.stringify(o.top_buttons || [], null, 2);
     updateMediaTopButtonsVisibility();
+  } else if (type === 'camera') {
+    document.getElementById('optName').value = o.name || '';
+    document.getElementById('optEntityId').value = o.entity_id || '';
+    document.getElementById('optCameraMode').value = o.mode === 'snapshot' ? 'snapshot' : 'stream';
+    document.getElementById('optCameraInterval').value = o.snapshot_interval ?? 2;
+    // Snap the aspect dropdown to the stored value when it matches a preset;
+    // an unusual custom aspect just shows the default here (the JSON keeps its
+    // own value until the card is re-saved from this form).
+    const aspSel = document.getElementById('optCameraAspect');
+    aspSel.value = (o.aspect != null) ? String(o.aspect) : '1.7778';
+    if (!aspSel.value) aspSel.value = '1.7778';
+    document.getElementById('optCameraFit').value = o.fit === 'contain' ? 'contain' : 'cover';
   } else if (type === 'fan') {
     document.getElementById('optName').value = o.name || '';
     document.getElementById('optEntityId').value = o.entity_id || '';
@@ -795,6 +831,16 @@ function addCardToPage() {
         return;
       }
     }
+  } else if (type === 'camera') {
+    const camName = document.getElementById('optName').value.trim();
+    if (camName) newCard.options.name = camName;
+    newCard.options.entity_id = document.getElementById('optEntityId').value || 'camera.entity';
+    if (document.getElementById('optCameraMode').value === 'snapshot') newCard.options.mode = 'snapshot';
+    const camInterval = parseInt(document.getElementById('optCameraInterval').value, 10);
+    if (Number.isFinite(camInterval) && camInterval !== 2) newCard.options.snapshot_interval = camInterval;
+    const camAspect = parseFloat(document.getElementById('optCameraAspect').value);
+    if (Number.isFinite(camAspect) && Math.abs(camAspect - 1.7778) > 0.001) newCard.options.aspect = camAspect;
+    if (document.getElementById('optCameraFit').value === 'contain') newCard.options.fit = 'contain';
   } else if (type === 'fan') {
     newCard.options.name = document.getElementById('optName').value || 'Fan';
     newCard.options.entity_id = document.getElementById('optEntityId').value || 'fan.entity';

--- a/docs/js/mocks.js
+++ b/docs/js/mocks.js
@@ -36,6 +36,8 @@ const MDI = {
   swingOff: 'M13,8.1V6.1C18.3,6.6 20,11.4 20,14H23L20.1,16.9L17.2,14H18C18,11.9 16.4,8.6 13,8.1M7.8,7.1L2.4,1.7L1.1,3L6.3,8.2C4.7,10 4,12.4 4,14H1L5,18L9,14H6C6,12.7 6.6,11 7.9,9.7L20.9,22.7L22.2,21.4L9.3,8.7L7.8,7.1M11,6.1L9.5,6.4L11,7.8V6.1Z',
   swingOn: 'M17.45,17.55L12,23L6.55,17.55L7.96,16.14L11,19.17V4.83L7.96,7.86L6.55,6.45L12,1L17.45,6.45L16.04,7.86L13,4.83V19.17L16.04,16.14L17.45,17.55Z',
   waterPercent: 'M12,3.25C12,3.25 6,10 6,14C6,17.32 8.69,20 12,20A6,6 0 0,0 18,14C18,10 12,3.25 12,3.25M14.47,9.97L15.53,11.03L9.53,17.03L8.47,15.97M9.75,10A1.25,1.25 0 0,1 11,11.25A1.25,1.25 0 0,1 9.75,12.5A1.25,1.25 0 0,1 8.5,11.25A1.25,1.25 0 0,1 9.75,10M14.25,14.5A1.25,1.25 0 0,1 15.5,15.75A1.25,1.25 0 0,1 14.25,17A1.25,1.25 0 0,1 13,15.75A1.25,1.25 0 0,1 14.25,14.5Z',
+  video: 'M17,10.5V7A1,1 0 0,0 16,6H4A1,1 0 0,0 3,7V17A1,1 0 0,0 4,18H16A1,1 0 0,0 17,17V13.5L21,17.5V6.5L17,10.5Z',
+  videoOff: 'M3.27,2L2,3.27L4.73,6H4A1,1 0 0,0 3,7V17A1,1 0 0,0 4,18H16A1,1 0 0,0 16.73,17.73L19.73,20.73L21,19.46M21,6.5L17,10.5V7A1,1 0 0,0 16,6H9.82L21,17.18V6.5Z',
 };
 function mdiSvg(path) { return `<svg viewBox="0 0 24 24" fill="currentColor"><path d="${path}"/></svg>`; }
 
@@ -276,6 +278,16 @@ const MEDIA_MOCK = {
   media_duration: 183,
   shuffle: false,
   repeat: 'off',
+};
+
+const CAMERA_MOCK = {
+  friendly_name: 'Front Door',
+  state: 'streaming', // idle | streaming
+  // entity_picture normally looks like /api/camera_proxy/camera.x?token=…; the
+  // static editor can't reach it, so the preview only uses this to know the
+  // entity is a camera. On a real device the preview fetches a live frame from
+  // /camera-snapshot instead.
+  entity_picture: null,
 };
 
 // Mirrors MediaPlayerCard.kt's Feature bitmask check (EntityState.supports).

--- a/docs/js/preview.js
+++ b/docs/js/preview.js
@@ -702,6 +702,32 @@ function renderPreview() {
           <div class="card-title"><span>${card.type} (${items.length} items)</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
           ${gridHtml}
         </div>`;
+    } else if (card.type === 'camera') {
+      const o = card.options || {};
+      const title = o.name || haFriendlyName(o.entity_id) || prettyEntityName(o.entity_id) || 'Camera';
+      const aspect = (o.aspect != null && Number(o.aspect) > 0) ? Number(o.aspect) : (16 / 9);
+      const fit = o.fit === 'contain' ? 'contain' : 'cover';
+      const mode = o.mode === 'snapshot' ? 'snapshot' : 'stream';
+      const paddingPct = (100 / aspect).toFixed(3);
+      // Only try to pull a real frame when the editor is served by the device
+      // itself (it has the HA token to proxy /camera-snapshot). On GitHub Pages
+      // / offline this stays a placeholder, like the other cards' live data.
+      const canFetch = (typeof deviceModeAvailable !== 'undefined' && deviceModeAvailable) && !!o.entity_id;
+      const snapUrl = canFetch ? `/camera-snapshot?entity=${encodeURIComponent(o.entity_id)}&_=${Date.now()}` : '';
+      const placeholder = `<div style="position:absolute; inset:0; display:flex; align-items:center; justify-content:center; color:#9FB6BD;"><div style="width:44px; height:44px;">${mdiSvg(MDI.video)}</div></div>`;
+      const imgHtml = snapUrl
+        ? `<img src="${snapUrl}" alt="${title}" style="position:absolute; inset:0; width:100%; height:100%; object-fit:${fit};" onerror="this.style.display='none'">`
+        : '';
+      cardEl.innerHTML = `
+        <div class="card">
+          <div class="card-title"><span>camera (${mode})</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
+          <div style="position:relative; width:100%; padding-top:${paddingPct}%; border-radius:14px; overflow:hidden; background:#0E1116;">
+            ${placeholder}
+            ${imgHtml}
+            <div style="position:absolute; left:0; right:0; bottom:0; padding:8px 12px; background:linear-gradient(to top, rgba(0,0,0,.75), transparent); color:#fff; font-weight:600; font-size:13px;">${title}</div>
+          </div>
+          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'camera.entity'} · ${canFetch ? 'live frame from this device' : "placeholder here — a real still shows when opened from your device's /builder/"} · on the remote: ${mode === 'stream' ? 'live MJPEG stream (auto-falls-back to stills)' : 'still snapshot refresh'}</div>
+        </div>`;
     } else {
       cardEl.className = 'card';
       cardEl.innerHTML = `


### PR DESCRIPTION
Adds a new `camera` card type and a fullscreen tap-to-maximize viewer.

## What's included

**`feat(cards): add camera card with live MJPEG stream + snapshot fallback`**
- New `CameraCard` renderer with stream (MJPEG) and snapshot (still-frame polling) modes
- Stream/snapshot-proxy client methods on `HaClient` (`fetchBytes`, `fetchBitmap`, `openStream`)
- `GET /camera-snapshot?entity=<id>` endpoint on the ConfigServer, proxying a single `camera.*` frame through the device's HA token so the dashboard editor preview can show a real frame without exposing the token to the browser
- Editor support: `camera` card form in `cards.js`, mock in `mocks.js`, and a live preview that points an `<img>` at `/camera-snapshot` when served from the device (falls back to a placeholder on GitHub Pages / HA offline)

**`feat(cards): tap-to-maximize camera card with pinch-zoom and pan`**
- Tap the inline card to open a fullscreen `Dialog` viewer over it; pinch zooms 1x–8x and drag pans, clamped so the zoomed image always covers the viewport
- The `Dialog` shares the existing frame state, so the live stream keeps flowing while zoomed
- `detectTransformGestures` drives a `graphicsLayer` scale + translation; offsets reset at 1x
- Close button (top-right) sits above the gesture layer; hardware BACK dismisses via the Dialog's native handler

## Config options

```json
{ "type": "camera", "options": {
    "entity_id": "camera.front_door",
    "mode": "stream",
    "snapshot_interval": 2,
    "aspect": 1.777,
    "fit": "cover"
} }
```

## Notes / scope

This PR is self-contained against `main`. A couple of refinements from my fork were intentionally left out to keep the PR focused (they ride on other commits not yet contributed):
- The `/camera-snapshot` endpoint here fetches `/api/camera_proxy/<entity>` directly via OkHttp using the stored HA token. My fork additionally prefers the live `entity_picture` attribute when available, but that depends on a `/ha-states`-style `haClient` hookup on the ConfigServer that isn't in this PR.
- The card background uses a hardcoded color; my fork uses a themed token, but the theme system is a separate contribution.

Built and verified on a HA100 (Android 8.1, MT6580).
