### PR TITLE
feat(editor): toast instead of alert for save to device

### DIFF
--- a/app/src/main/assets/docs/index.html
+++ b/app/src/main/assets/docs/index.html
@@ -360,6 +360,8 @@
   </div>
 </div>
 
+<div id="toast" class="toast"></div>
+
 <script src="js/mocks.js"></script>
 <script src="js/pages.js"></script>
 <script src="js/cards.js"></script>

--- a/app/src/main/assets/docs/js/device.js
+++ b/app/src/main/assets/docs/js/device.js
@@ -7,6 +7,21 @@
 
 let deviceModeAvailable = false; // true once we've confirmed we're being served by the app
 
+// Slide-up toast notification. Replaces the blocking alert() that "Save to
+// device" used to pop — non-modal, auto-dismisses (3s success / 5s error),
+// falls back to alert() if the #toast element isn't present.
+let _toastTimer = null;
+function showToast(msg, type) {
+  const el = document.getElementById('toast');
+  if (!el) { alert(msg); return; }
+  el.textContent = msg;
+  el.className = 'toast' + (type === 'error' ? ' error' : '');
+  void el.offsetWidth; // restart transition if a toast is already showing
+  el.classList.add('show');
+  clearTimeout(_toastTimer);
+  _toastTimer = setTimeout(() => el.classList.remove('show'), type === 'error' ? 5000 : 3000);
+}
+
 async function loadDashboardFromDevice() {
   try {
     const res = await fetch('/dashboard.json');
@@ -51,7 +66,7 @@ async function saveDashboardToDevice() {
   try {
     JSON.parse(jsonText); // fail fast with a clear message rather than let the app reject a bad upload silently
   } catch (e) {
-    alert('Invalid JSON: ' + e.message);
+    showToast('Invalid JSON: ' + e.message, 'error');
     return;
   }
   const btn = document.getElementById('saveToDeviceBtn');
@@ -63,9 +78,9 @@ async function saveDashboardToDevice() {
     form.append('file', new Blob([jsonText], { type: 'application/json' }), 'dashboard.json');
     const res = await fetch('/dashboard.json', { method: 'POST', body: form });
     if (!res.ok) throw new Error('HTTP ' + res.status);
-    alert('Saved to this device — the dashboard reloads automatically.');
+    showToast('Saved — the dashboard reloads automatically.');
   } catch (e) {
-    alert('Save failed: ' + e);
+    showToast('Save failed: ' + e, 'error');
   } finally {
     btn.textContent = originalText;
     btn.disabled = false;

--- a/app/src/main/assets/docs/styles.css
+++ b/app/src/main/assets/docs/styles.css
@@ -15,6 +15,20 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   button.secondary:hover { background: #444; }
   button.danger { background: #3a2222; color: #ff8a8a; }
   button.danger:hover { background: #4a2a2a; }
+  /* Toast — slide-up notification replacing modal alert() for transient
+     confirmations like "Save to device". Stays out of the way (fixed
+     bottom-center, non-blocking) and auto-dismisses. */
+  .toast {
+    position: fixed; bottom: 24px; left: 50%;
+    transform: translateX(-50%) translateY(140%);
+    background: #2d2d2d; color: #fff; border: 1px solid #444;
+    border-left: 4px solid #00E5FF; padding: 12px 18px; border-radius: 8px;
+    font-size: 0.85rem; max-width: 90vw; box-shadow: 0 6px 24px rgba(0,0,0,0.55);
+    z-index: 10000; opacity: 0; pointer-events: none;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+  }
+  .toast.show { transform: translateX(-50%) translateY(0); opacity: 1; }
+  .toast.error { border-left-color: #ff5252; }
   .section-box { background: #252525; padding: 14px; border-radius: 8px; border: 1px solid #383838; margin-bottom: 14px; }
   .row { display: flex; gap: 10px; }
   .row > * { flex: 1; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -360,6 +360,8 @@
   </div>
 </div>
 
+<div id="toast" class="toast"></div>
+
 <script src="js/mocks.js"></script>
 <script src="js/pages.js"></script>
 <script src="js/cards.js"></script>

--- a/docs/js/device.js
+++ b/docs/js/device.js
@@ -7,6 +7,21 @@
 
 let deviceModeAvailable = false; // true once we've confirmed we're being served by the app
 
+// Slide-up toast notification. Replaces the blocking alert() that "Save to
+// device" used to pop — non-modal, auto-dismisses (3s success / 5s error),
+// falls back to alert() if the #toast element isn't present.
+let _toastTimer = null;
+function showToast(msg, type) {
+  const el = document.getElementById('toast');
+  if (!el) { alert(msg); return; }
+  el.textContent = msg;
+  el.className = 'toast' + (type === 'error' ? ' error' : '');
+  void el.offsetWidth; // restart transition if a toast is already showing
+  el.classList.add('show');
+  clearTimeout(_toastTimer);
+  _toastTimer = setTimeout(() => el.classList.remove('show'), type === 'error' ? 5000 : 3000);
+}
+
 async function loadDashboardFromDevice() {
   try {
     const res = await fetch('/dashboard.json');
@@ -51,7 +66,7 @@ async function saveDashboardToDevice() {
   try {
     JSON.parse(jsonText); // fail fast with a clear message rather than let the app reject a bad upload silently
   } catch (e) {
-    alert('Invalid JSON: ' + e.message);
+    showToast('Invalid JSON: ' + e.message, 'error');
     return;
   }
   const btn = document.getElementById('saveToDeviceBtn');
@@ -63,9 +78,9 @@ async function saveDashboardToDevice() {
     form.append('file', new Blob([jsonText], { type: 'application/json' }), 'dashboard.json');
     const res = await fetch('/dashboard.json', { method: 'POST', body: form });
     if (!res.ok) throw new Error('HTTP ' + res.status);
-    alert('Saved to this device — the dashboard reloads automatically.');
+    showToast('Saved — the dashboard reloads automatically.');
   } catch (e) {
-    alert('Save failed: ' + e);
+    showToast('Save failed: ' + e, 'error');
   } finally {
     btn.textContent = originalText;
     btn.disabled = false;

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -15,6 +15,20 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   button.secondary:hover { background: #444; }
   button.danger { background: #3a2222; color: #ff8a8a; }
   button.danger:hover { background: #4a2a2a; }
+  /* Toast — slide-up notification replacing modal alert() for transient
+     confirmations like "Save to device". Stays out of the way (fixed
+     bottom-center, non-blocking) and auto-dismisses. */
+  .toast {
+    position: fixed; bottom: 24px; left: 50%;
+    transform: translateX(-50%) translateY(140%);
+    background: #2d2d2d; color: #fff; border: 1px solid #444;
+    border-left: 4px solid #00E5FF; padding: 12px 18px; border-radius: 8px;
+    font-size: 0.85rem; max-width: 90vw; box-shadow: 0 6px 24px rgba(0,0,0,0.55);
+    z-index: 10000; opacity: 0; pointer-events: none;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+  }
+  .toast.show { transform: translateX(-50%) translateY(0); opacity: 1; }
+  .toast.error { border-left-color: #ff5252; }
   .section-box { background: #252525; padding: 14px; border-radius: 8px; border: 1px solid #383838; margin-bottom: 14px; }
   .row { display: flex; gap: 10px; }
   .row > * { flex: 1; }


### PR DESCRIPTION
Replaces the browser `alert()` on save-to-device with a non-blocking toast notification.

- Adds a small toast component (`styles.css`) that slides in on save and auto-dismisses
- `device.js` swapped from `alert()` to the toast; preserves the existing success/error messaging
- No Kotlin changes — editor-only

Matches the editor's existing inline-feedback pattern (e.g. icon upload, harmony discovery) instead of modal dialogs that interrupt the workflow.
