### PR TITLE
feat(editor): drag page tabs to reorder

### DIFF
--- a/app/src/main/assets/docs/js/pages.js
+++ b/app/src/main/assets/docs/js/pages.js
@@ -184,3 +184,25 @@ function deletePageFromDialog() {
   closePageDialog();
   renderTabs(); renderPreview(); renderHotkeysList(); updateJsonOutput();
 }
+
+// Reorder a page from fromIdx to toIdx by dragging its tab. Mirrors
+// reorderCard() but operates on dashboardData.pages and fixes the two
+// positional indices that reference pages by number: startPage (the launch
+// page) and currentActivePage (the tab being viewed in the editor). Both must
+// follow the page they point to across the splice, otherwise a drag would
+// silently change which page launches at boot or which one is shown.
+function reorderPage(fromIdx, toIdx) {
+  const pages = dashboardData.pages;
+  if (fromIdx < 0 || fromIdx >= pages.length || toIdx < 0 || toIdx >= pages.length || fromIdx === toIdx) return;
+  const [moved] = pages.splice(fromIdx, 1);
+  pages.splice(toIdx, 0, moved);
+  const fixIndex = (i) => {
+    if (i === fromIdx) return toIdx;
+    if (fromIdx < toIdx) { if (i > fromIdx && i <= toIdx) return i - 1; }
+    else { if (i >= toIdx && i < fromIdx) return i + 1; }
+    return i;
+  };
+  dashboardData.startPage = fixIndex(dashboardData.startPage);
+  currentActivePage = fixIndex(currentActivePage);
+  renderTabs(); renderPreview(); renderHotkeysList(); updateJsonOutput();
+}

--- a/app/src/main/assets/docs/js/preview.js
+++ b/app/src/main/assets/docs/js/preview.js
@@ -7,12 +7,33 @@ function renderTabs() {
     const tab = document.createElement('div');
     const isActive = index === currentActivePage;
     tab.className = `tab ${isActive ? 'active' : ''}`;
+    tab.dataset.pageIdx = String(index);
 
     const label = document.createElement('span');
     label.textContent = (page.parent ? '↳ ' : '') + page.name + (index === dashboardData.startPage ? ' 🏠' : '');
     if (page.parent) label.title = `Child of "${page.parent}"`;
     tab.appendChild(label);
     tab.onclick = () => onPageChange(index);
+
+    // Drag-to-reorder, mirroring enhanceCardControls() below. Dropping a tab
+    // onto another tab repositions its page in dashboardData.pages; the active
+    // tab and start page follow their pages via reorderPage()'s index fixup.
+    tab.setAttribute('draggable', 'true');
+    tab.addEventListener('dragstart', (e) => {
+      tab.classList.add('dragging');
+      e.dataTransfer.effectAllowed = 'move';
+      e.dataTransfer.setData('text/plain', String(index));
+    });
+    tab.addEventListener('dragend', () => tab.classList.remove('dragging'));
+    tab.addEventListener('dragover', (e) => { e.preventDefault(); tab.classList.add('drag-over'); });
+    tab.addEventListener('dragleave', () => tab.classList.remove('drag-over'));
+    tab.addEventListener('drop', (e) => {
+      e.preventDefault();
+      tab.classList.remove('drag-over');
+      const fromIdx = parseInt(e.dataTransfer.getData('text/plain'), 10);
+      const toIdx = parseInt(tab.dataset.pageIdx, 10);
+      if (!isNaN(fromIdx) && !isNaN(toIdx) && fromIdx !== toIdx) reorderPage(fromIdx, toIdx);
+    });
 
     if (isActive) {
       const gear = document.createElement('span');

--- a/app/src/main/assets/docs/styles.css
+++ b/app/src/main/assets/docs/styles.css
@@ -28,6 +28,12 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   .tab-settings { opacity: 0.7; }
   .tab-settings:hover { opacity: 1; }
   .tab.active .tab-settings { color: #121212; }
+  /* Drag-to-reorder page tabs — same visual language as the card reorder
+     affordances below (.ha-draggable-card), just applied to the tab bar. */
+  .tab[draggable="true"] { cursor: grab; }
+  .tab[draggable="true"]:active { cursor: grabbing; }
+  .tab.dragging { opacity: 0.4; }
+  .tab.drag-over { outline: 2px dashed #00E5FF; outline-offset: 2px; }
   /* Card dialog (add/edit) and page dialog reuse .preview-modal, just wider
      and left-aligned like the rest of the form fields, mirroring the way
      Home Assistant edits a card in a dedicated dialog rather than inline. */

--- a/docs/js/pages.js
+++ b/docs/js/pages.js
@@ -184,3 +184,25 @@ function deletePageFromDialog() {
   closePageDialog();
   renderTabs(); renderPreview(); renderHotkeysList(); updateJsonOutput();
 }
+
+// Reorder a page from fromIdx to toIdx by dragging its tab. Mirrors
+// reorderCard() but operates on dashboardData.pages and fixes the two
+// positional indices that reference pages by number: startPage (the launch
+// page) and currentActivePage (the tab being viewed in the editor). Both must
+// follow the page they point to across the splice, otherwise a drag would
+// silently change which page launches at boot or which one is shown.
+function reorderPage(fromIdx, toIdx) {
+  const pages = dashboardData.pages;
+  if (fromIdx < 0 || fromIdx >= pages.length || toIdx < 0 || toIdx >= pages.length || fromIdx === toIdx) return;
+  const [moved] = pages.splice(fromIdx, 1);
+  pages.splice(toIdx, 0, moved);
+  const fixIndex = (i) => {
+    if (i === fromIdx) return toIdx;
+    if (fromIdx < toIdx) { if (i > fromIdx && i <= toIdx) return i - 1; }
+    else { if (i >= toIdx && i < fromIdx) return i + 1; }
+    return i;
+  };
+  dashboardData.startPage = fixIndex(dashboardData.startPage);
+  currentActivePage = fixIndex(currentActivePage);
+  renderTabs(); renderPreview(); renderHotkeysList(); updateJsonOutput();
+}

--- a/docs/js/preview.js
+++ b/docs/js/preview.js
@@ -7,12 +7,33 @@ function renderTabs() {
     const tab = document.createElement('div');
     const isActive = index === currentActivePage;
     tab.className = `tab ${isActive ? 'active' : ''}`;
+    tab.dataset.pageIdx = String(index);
 
     const label = document.createElement('span');
     label.textContent = (page.parent ? '↳ ' : '') + page.name + (index === dashboardData.startPage ? ' 🏠' : '');
     if (page.parent) label.title = `Child of "${page.parent}"`;
     tab.appendChild(label);
     tab.onclick = () => onPageChange(index);
+
+    // Drag-to-reorder, mirroring enhanceCardControls() below. Dropping a tab
+    // onto another tab repositions its page in dashboardData.pages; the active
+    // tab and start page follow their pages via reorderPage()'s index fixup.
+    tab.setAttribute('draggable', 'true');
+    tab.addEventListener('dragstart', (e) => {
+      tab.classList.add('dragging');
+      e.dataTransfer.effectAllowed = 'move';
+      e.dataTransfer.setData('text/plain', String(index));
+    });
+    tab.addEventListener('dragend', () => tab.classList.remove('dragging'));
+    tab.addEventListener('dragover', (e) => { e.preventDefault(); tab.classList.add('drag-over'); });
+    tab.addEventListener('dragleave', () => tab.classList.remove('drag-over'));
+    tab.addEventListener('drop', (e) => {
+      e.preventDefault();
+      tab.classList.remove('drag-over');
+      const fromIdx = parseInt(e.dataTransfer.getData('text/plain'), 10);
+      const toIdx = parseInt(tab.dataset.pageIdx, 10);
+      if (!isNaN(fromIdx) && !isNaN(toIdx) && fromIdx !== toIdx) reorderPage(fromIdx, toIdx);
+    });
 
     if (isActive) {
       const gear = document.createElement('span');

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -28,6 +28,12 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   .tab-settings { opacity: 0.7; }
   .tab-settings:hover { opacity: 1; }
   .tab.active .tab-settings { color: #121212; }
+  /* Drag-to-reorder page tabs — same visual language as the card reorder
+     affordances below (.ha-draggable-card), just applied to the tab bar. */
+  .tab[draggable="true"] { cursor: grab; }
+  .tab[draggable="true"]:active { cursor: grabbing; }
+  .tab.dragging { opacity: 0.4; }
+  .tab.drag-over { outline: 2px dashed #00E5FF; outline-offset: 2px; }
   /* Card dialog (add/edit) and page dialog reuse .preview-modal, just wider
      and left-aligned like the rest of the form fields, mirroring the way
      Home Assistant edits a card in a dedicated dialog rather than inline. */


### PR DESCRIPTION
Adds drag-to-reorder for the page tabs in the dashboard editor.

- Page tabs in the left pane are now draggable; dropping a tab onto another reorders the `pages` array in the config
- `pages.js`: drag handlers update the in-memory page order and persist on drop
- `preview.js`: the on-screen "remote" preview re-renders its page indicator dots and swipe order to match
- `styles.css`: drag affordance (cursor + subtle highlight) on the grabbed tab
- Editor-only — no Kotlin changes
