### PR TITLE
feat(ui): configurable theme colors via the dashboard editor

### DIFF
--- a/app/src/main/assets/docs/index.html
+++ b/app/src/main/assets/docs/index.html
@@ -124,7 +124,10 @@
       <div id="activitiesList" style="margin-top:12px"></div>
     </div>
 
-    <h2>4. Generated JSON</h2>
+    <h2>4. Theme & Colors</h2>
+    <div class="section-box" id="themeBox"></div>
+
+    <h2>5. Generated JSON</h2>
     <textarea id="jsonOutput" readonly></textarea>
     <div class="btn-row">
       <button onclick="copyJson()">Copy JSON</button>
@@ -367,6 +370,7 @@
 <script src="js/hotkeys.js"></script>
 <script src="js/ir.js"></script>
 <script src="js/activities.js"></script>
+<script src="js/theme.js"></script>
 <script src="js/export.js"></script>
 <script src="js/preview.js"></script>
 <script src="js/device.js"></script>

--- a/app/src/main/assets/docs/js/cards.js
+++ b/app/src/main/assets/docs/js/cards.js
@@ -1,6 +1,6 @@
 // ---- Cards ---------------------------------------------------------------
 
-const NAME_ENTITY_TYPES = ['switch', 'source_select'];
+const NAME_ENTITY_TYPES = ['source_select'];
 
 function updateCardFormInputs() {
   const type = document.getElementById('cardTypeSelect').value;
@@ -27,6 +27,13 @@ function updateCardFormInputs() {
       <label class="inline-check"><input type="checkbox" id="optTitleDivider"> Divider line (fills the rest of the row after the title)</label>
       <label>Color (optional, ARGB/RGB hex — defaults to the standard title color, also tints the divider line)</label><input type="text" id="optTitleColor" placeholder="#7FB3C4">
       <div class="hint">A section header for grouping the cards below it — no entity of its own. Setting an icon or the divider always left-aligns the title row regardless of Alignment (that layout has no sensible centered/right-aligned form) — the subtitle below is unaffected. For a tappable title/subtitle (e.g. a "see all" link to another page), use "Other / custom type…" below instead and add title_page / subtitle_page — or any of scene_grid's other action fields with a title_/subtitle_ prefix — directly in the JSON; like every type here, re-saving through this simple form overwrites the card's options from scratch, so those fields wouldn't survive a later edit through it.</div>
+    `;
+  } else if (type === 'switch') {
+    container.innerHTML = `
+      <label>Name</label><input type="text" id="optName" placeholder="e.g., Living Room">
+      <label>Entity ID</label><input type="text" id="optEntityId" placeholder="e.g., switch.living_room">
+      <label>"On" color (optional, ARGB hex — defaults to green)</label>${colorFieldHtml('optOnColor', '', '#FF2E5A46')}
+      ${iconFieldHtml('optIcon')}
     `;
   } else if (type === 'cover') {
     container.innerHTML = `
@@ -191,7 +198,7 @@ function updateCardFormInputs() {
             ${(dashboardData.activities || []).map(a => `<option value="${a.id}">${a.name} (${a.room})</option>`).join('')}
           </select>
           ${(dashboardData.activities || []).length === 0 ? '<div class="hint">No Activities yet — create one in the "Activities" section below for multi-device setups (e.g. IR-only, no Harmony/HA).</div>' : ''}
-          <label>Color (optional, ARGB hex — defaults to the standard tile color)</label><input type="text" id="giColor" placeholder="#66009688">
+          <label>Color (optional, ARGB hex — defaults to the standard tile color)</label>${colorFieldHtml('giColor', '', '#66009688')}
           <div class="divider" style="margin:12px 0"></div>
           <label><input type="checkbox" id="giTrack" onchange="onGiTrackChange()"> Track as Activity</label>
           <div class="hint">Makes this tile show up as the active AV Activity for its room — see ActivityRuntime. At most one tracked Activity is active per room at a time. Not needed if you picked a Composed Activity above — that's always tracked automatically, using its own room.</div>
@@ -354,7 +361,7 @@ function fillGridItemForm(type, item) {
     }
     const actRefSel = document.getElementById('giActivityRef');
     if (actRefSel) actRefSel.value = item.activity || '';
-    document.getElementById('giColor').value = item.color || '';
+    setColorFieldValue('giColor', item.color || '');
     document.getElementById('giTrack').checked = item.track === true;
     document.getElementById('giRoom').value = item.room || '';
     document.getElementById('giDevices').value = (item.devices || []).join(', ');
@@ -411,10 +418,11 @@ function cancelGridItemEdit() {
   document.getElementById('giName').value = '';
   document.getElementById('giIcon').value = '';
   updateIconThumb('giIcon');
-  ['giService', 'giEntityId', 'giData', 'giPage', 'giIrDevice', 'giIrCommand', 'giActivityRef', 'giColor'].forEach(id => {
+  ['giService', 'giEntityId', 'giData', 'giPage', 'giIrDevice', 'giIrCommand', 'giActivityRef'].forEach(id => {
     const el = document.getElementById(id);
     if (el) el.value = '';
   });
+  setColorFieldValue('giColor', '');
   const trackEl = document.getElementById('giTrack');
   if (trackEl) { trackEl.checked = false; document.getElementById('giRoom').value = ''; document.getElementById('giDevices').value = ''; onGiTrackChange(); }
   const harmonyModeSel = document.getElementById('giHarmonyMode');
@@ -443,7 +451,7 @@ function addGridItem(type) {
     const irDevice = document.getElementById('giIrDevice')?.value || '';
     const irCommand = document.getElementById('giIrCommand')?.value || '';
     const activityRef = document.getElementById('giActivityRef')?.value || '';
-    const color = document.getElementById('giColor').value.trim();
+    const color = colorFieldValue('giColor');
     if (entityId) item.entity_id = entityId;
     if (page) item.page = page;
     if (irDevice && irCommand) { item.irDevice = irDevice; item.irCommand = irCommand; }
@@ -581,6 +589,12 @@ function fillCardForm(card) {
     updateIconThumb('optTitleIcon');
     document.getElementById('optTitleDivider').checked = o.divider === true;
     document.getElementById('optTitleColor').value = o.color || '';
+  } else if (type === 'switch') {
+    document.getElementById('optName').value = o.name || '';
+    document.getElementById('optEntityId').value = o.entity_id || '';
+    setColorFieldValue('optOnColor', o.on_color || '');
+    document.getElementById('optIcon').value = o.icon || '';
+    updateIconThumb('optIcon');
   } else if (type === 'cover') {
     document.getElementById('optName').value = o.name || '';
     document.getElementById('optEntityId').value = o.entity_id || '';
@@ -728,6 +742,13 @@ function addCardToPage() {
     if (document.getElementById('optTitleDivider').checked) newCard.options.divider = true;
     const titleColor = document.getElementById('optTitleColor').value.trim();
     if (titleColor) newCard.options.color = titleColor;
+  } else if (type === 'switch') {
+    newCard.options.name = document.getElementById('optName').value || 'Switch';
+    newCard.options.entity_id = document.getElementById('optEntityId').value || 'switch.entity';
+    const onColor = colorFieldValue('optOnColor');
+    if (onColor) newCard.options.on_color = onColor;
+    const icon = document.getElementById('optIcon').value.trim();
+    if (icon) newCard.options.icon = icon;
   } else if (type === 'cover') {
     const coverName = document.getElementById('optName').value.trim();
     if (coverName) newCard.options.name = coverName;

--- a/app/src/main/assets/docs/js/device.js
+++ b/app/src/main/assets/docs/js/device.js
@@ -39,6 +39,7 @@ function applyParsedDashboard(parsed) {
     longHotkeys: parsed.longHotkeys || [],
     irDevices: parsed.irDevices || [],
     activities: parsed.activities || [],
+    theme: parsed.theme || {},
   };
   if (dashboardData.pages.length === 0) {
     dashboardData.pages.push({ name: "Home", cards: [], hotkeys: [], longHotkeys: [] });

--- a/app/src/main/assets/docs/js/pages.js
+++ b/app/src/main/assets/docs/js/pages.js
@@ -1,4 +1,4 @@
-let dashboardData = { startPage: 0, pages: [ { name: "Home", cards: [], hotkeys: [], longHotkeys: [] } ], hotkeys: [], longHotkeys: [], irDevices: [], activities: [] };
+let dashboardData = { startPage: 0, pages: [ { name: "Home", cards: [], hotkeys: [], longHotkeys: [] } ], hotkeys: [], longHotkeys: [], irDevices: [], activities: [], theme: {} };
 let currentActivePage = 0;
 let editingCard = null;    // index of the card being edited within the current page, or null
 let editingHotkey = null;  // { scope, listType, i } of the hotkey being edited, or null
@@ -25,7 +25,7 @@ function slugify(name, fallbackPrefix) {
 }
 
 function resetAll() {
-  dashboardData = { startPage: 0, pages: [ { name: "Home", cards: [], hotkeys: [], longHotkeys: [] } ], hotkeys: [], longHotkeys: [], irDevices: [], activities: [] };
+  dashboardData = { startPage: 0, pages: [ { name: "Home", cards: [], hotkeys: [], longHotkeys: [] } ], hotkeys: [], longHotkeys: [], irDevices: [], activities: [], theme: {} };
   currentActivePage = 0;
   document.getElementById('importBox').value = '';
   initEditor();
@@ -49,6 +49,7 @@ function importJson() {
       longHotkeys: parsed.longHotkeys || [],
       irDevices: parsed.irDevices || [],
       activities: parsed.activities || [],
+      theme: parsed.theme || {},
     };
     if (dashboardData.pages.length === 0) dashboardData.pages.push({ name: "Home", cards: [], hotkeys: [], longHotkeys: [] });
     currentActivePage = 0;
@@ -68,6 +69,8 @@ function initEditor() {
   renderHotkeysList();
   renderIrDevicesList();
   renderActivitiesList();
+  if (typeof renderThemeForm === 'function') renderThemeForm();
+  if (typeof applyThemeToPreview === 'function') applyThemeToPreview();
   updateJsonOutput();
   updateHotkeyActionInputs();
 }

--- a/app/src/main/assets/docs/js/preview.js
+++ b/app/src/main/assets/docs/js/preview.js
@@ -367,8 +367,8 @@ function renderPreview() {
       const cycleBtnHtml = enabledControls.length > 1 ? `<div class="pc-cycle-btn" title="Cycles through: ${enabledControls.join(', ')}">${mdiSvg(MDI.chevronRight)}</div>` : '';
       const controlsHtml = (full) => {
         let inner;
-        if (activeControl === 'position') inner = sliderHtml(position, '#6FA8DC');
-        else if (activeControl === 'tilt') inner = sliderHtml(tilt, '#8FBF7F');
+        if (activeControl === 'position') inner = sliderHtml(position, 'var(--accent)');
+        else if (activeControl === 'tilt') inner = sliderHtml(tilt, 'var(--success)');
         else if (activeControl === 'buttons') inner = buttonsHtml(full);
         else return '';
         return `<div style="display:flex; align-items:center; gap:8px; width:100%;"><div style="flex:1; min-width:0;">${inner}</div>${cycleBtnHtml}</div>`;
@@ -484,8 +484,8 @@ function renderPreview() {
       const [r, g, b] = LIGHT_MOCK.rgb_color || kelvinToPreviewRgb(LIGHT_MOCK.color_temp_kelvin);
       const lightColorCss = (isOn && useLightColor) ? `rgb(${r},${g},${b})` : null;
       const iconPath = isOn ? MDI.lightbulbOn : MDI.lightbulbOff;
-      const iconBg = !isOn ? '#2A4954' : (lightColorCss ? `rgba(${r},${g},${b},0.22)` : '#FFC24B');
-      const iconTint = !isOn ? '#B6C9CE' : (lightColorCss || '#241A00');
+      const iconBg = !isOn ? 'var(--control)' : (lightColorCss ? `rgba(${r},${g},${b},0.22)` : 'var(--amber)');
+      const iconTint = !isOn ? 'var(--icon)' : (lightColorCss || '#241A00');
       const barColor = lightColorCss || '#FFC24B';
 
       // Mirrors LightCard.kt: if none of the 3 flags are set at all, fall
@@ -611,10 +611,10 @@ function renderPreview() {
             </div>
             <div style="width:100%">
               <div class="pm-progress"><div class="pm-progress-fill" style="width:${fraction * 100}%"></div></div>
-              <div style="display:flex; justify-content:space-between; margin-top:4px;"><small style="color:#93AFB6">${fmtTime(mock.media_position)}</small><small style="color:#93AFB6">${fmtTime(mock.media_duration)}</small></div>
+              <div style="display:flex; justify-content:space-between; margin-top:4px;"><small style="color:var(--muted)">${fmtTime(mock.media_position)}</small><small style="color:var(--muted)">${fmtTime(mock.media_duration)}</small></div>
             </div>
             ${mediaButtons.length ? `<div class="pm-full-controls">${mediaButtons.map(b => btnHtml(b, true, true)).join('')}</div>` : ''}
-            ${(volumeButtons.length || hasVolumeSlider) ? `<div class="pm-full-controls">${hasVolumeSlider ? '<div style="flex:1; height:8px; border-radius:4px; background:#152B33; margin:0 8px;"><div style="width:' + Math.round((mock.volume_level || 0) * 100) + '%; height:100%; border-radius:4px; background:#4C6EF5;"></div></div>' : ''}${volumeButtons.map(b => btnHtml(b, true, false)).join('')}</div>` : ''}
+            ${(volumeButtons.length || hasVolumeSlider) ? `<div class="pm-full-controls">${hasVolumeSlider ? '<div style="flex:1; height:8px; border-radius:4px; background:var(--inset); margin:0 8px;"><div style="width:' + Math.round((mock.volume_level || 0) * 100) + '%; height:100%; border-radius:4px; background:var(--accent2);"></div></div>' : ''}${volumeButtons.map(b => btnHtml(b, true, false)).join('')}</div>` : ''}
           </div>`;
       } else {
         const hasMediaGroup = mediaButtons.length > 0;
@@ -636,7 +636,7 @@ function renderPreview() {
             </div>
             ${(hasMediaGroup || hasVolumeGroup) ? `
             <div class="pm-controls">
-              ${showingVolume && hasVolumeSlider ? '<div style="flex:1; height:36px; border-radius:10px; background:#152B33;"><div style="width:' + Math.round((mock.volume_level || 0) * 100) + '%; height:100%; border-radius:10px; background:#4C6EF5;"></div></div>' : ''}
+              ${showingVolume && hasVolumeSlider ? '<div style="flex:1; height:36px; border-radius:10px; background:var(--inset);"><div style="width:' + Math.round((mock.volume_level || 0) * 100) + '%; height:100%; border-radius:10px; background:var(--accent2);"></div></div>' : ''}
               ${activeButtons.map(b => btnHtml(b, false, true)).join('')}
               ${(hasMediaGroup && hasVolumeGroup) ? `<div class="pm-btn pm-swap">${mdiSvg(showingVolume ? MDI.play : MDI.volumeHigh)}</div>` : ''}
             </div>` : ''}
@@ -665,7 +665,7 @@ function renderPreview() {
         const label = item.name || '?';
         const src = iconUrl(item.icon);
         if (isScene) {
-          const bg = parseHexColorCss(item.color) || '#2A4954';
+          const bg = parseHexColorCss(item.color) || (typeof themeValues === 'function' ? themeValues().controlBackground : '#2C4C58');
           const textColor = textColorForBg(bg);
           const iconCell = hasIconGrid
             ? (src

--- a/app/src/main/assets/docs/js/theme.js
+++ b/app/src/main/assets/docs/js/theme.js
@@ -1,0 +1,280 @@
+// ---- Theme & Colors ---------------------------------------------------------
+//
+// Global dashboard theme: 12 semantic color tokens stored in
+// dashboardData.theme. The editor preview reflects changes live by setting
+// CSS variables on the .remote-screen node (the preview surface), which the
+// card renderer styles in styles.css consume via var(--token). On save,
+// updateJsonOutput() serializes dashboardData.theme into dashboard.json
+// automatically — no separate save step.
+
+// Token definitions: key (JSON/CSS), label, default hex (matches the app's
+// compiled-in ThemeConfig defaults so an untouched theme renders identically).
+const THEME_TOKENS = [
+  { group: 'Backgrounds', items: [
+    { key: 'background',       label: 'Window background',  default: '#0E2229' },
+    { key: 'cardSurface',      label: 'Card surface',       default: '#1B343D' },
+    { key: 'insetSurface',     label: 'Inset / recessed',   default: '#152B33' },
+    { key: 'controlBackground',label: 'Control / button',   default: '#2C4C58' },
+  ]},
+  { group: 'Text & Icons', items: [
+    { key: 'primaryText',      label: 'Primary text',       default: '#E6F0F1' },
+    { key: 'mutedText',        label: 'Muted text',         default: '#93AFB6' },
+    { key: 'iconTint',         label: 'Icon tint',          default: '#CBDCE0' },
+  ]},
+  { group: 'Accents', items: [
+    { key: 'accent',           label: 'Accent (blue)',      default: '#6EA8FE' },
+    { key: 'accentSecondary',  label: 'Accent 2 (indigo)',  default: '#4C6EF5' },
+    { key: 'amber',            label: 'Amber / light',      default: '#FFC24B' },
+  ]},
+  { group: 'Status', items: [
+    { key: 'danger',           label: 'Danger / off',       default: '#E06767' },
+    { key: 'success',          label: 'Success / on',       default: '#4CAF50' },
+  ]},
+];
+
+// All token keys flattened (used for defaults / normalization).
+const THEME_KEYS = THEME_TOKENS.flatMap(g => g.items.map(t => t.key));
+
+// Returns dashboardData.theme, backfilled with defaults for any missing token
+// so renderers can always read a value.
+function themeValues() {
+  const t = dashboardData.theme || {};
+  const out = {};
+  THEME_TOKENS.forEach(g => g.items.forEach(tok => {
+    out[tok.key] = t[tok.key] || tok.default;
+  }));
+  return out;
+}
+
+// Builds the Theme & Colors form (swatch + hex text field per token) into
+// #themeBox. Called once from initEditor(); inputs persist across re-renders
+// of the preview (only the preview re-renders, not this form).
+function renderThemeForm() {
+  const box = document.getElementById('themeBox');
+  if (!box) return;
+  const vals = themeValues();
+  let html = '';
+  html += `<div class="hint" style="margin-bottom:10px">Colors used across every card and the dashboard shell. Defaults match the built-in look — change any to customize. The preview updates live.</div>`;
+  THEME_TOKENS.forEach(group => {
+    html += `<div class="theme-group-label">${group.group}</div>`;
+    group.items.forEach(tok => {
+      const v = vals[tok.key];
+      const isDefault = v.toLowerCase() === tok.default.toLowerCase();
+      html += `
+        <div class="theme-row">
+          <input type="color" class="theme-swatch" id="themeSwatch_${tok.key}" value="${v}" onchange="onThemeInput('${tok.key}', this.value)" oninput="onThemeInput('${tok.key}', this.value, true)">
+          <input type="text" class="theme-hex" id="themeHex_${tok.key}" value="${v}" placeholder="${tok.default}" onchange="onThemeHexInput('${tok.key}', this.value)" oninput="onThemeHexInput('${tok.key}', this.value, true)">
+          <label class="theme-token-label" for="themeHex_${tok.key}">${tok.label}</label>
+          <button type="button" class="theme-reset-btn${isDefault ? ' is-default' : ''}" title="Reset to default (${tok.default})" onclick="resetThemeToken('${tok.key}')">↺</button>
+        </div>`;
+    });
+  });
+  html += `<div class="btn-row" style="margin-top:10px"><button class="secondary" onclick="resetTheme()">Reset to defaults</button></div>`;
+  box.innerHTML = html;
+}
+
+// Swatch -> value (always #RRGGBB). `live` = during drag (input event): update
+// preview without re-rendering the whole preview (CSS vars only).
+function onThemeInput(key, value, live) {
+  const hexInput = document.getElementById('themeHex_' + key);
+  if (hexInput) hexInput.value = value;
+  dashboardData.theme = dashboardData.theme || {};
+  dashboardData.theme[key] = value;
+  updateResetBtnState(key, value);
+  applyThemeToPreview();
+  if (!live) updateJsonOutput();
+}
+
+// Hex text field -> normalize to #RRGGBB; keep the swatch in sync.
+function onThemeHexInput(key, value, live) {
+  let v = (value || '').trim();
+  if (!v) v = (dashboardData.theme || {})[key] || (THEME_TOKENS.flatMap(g => g.items).find(t => t.key === key) || {}).default || '#000000';
+  if (v[0] !== '#') v = '#' + v;
+  if (/^#[0-9A-Fa-f]{6}$/.test(v)) {
+    const swatch = document.getElementById('themeSwatch_' + key);
+    if (swatch) swatch.value = v;
+    dashboardData.theme = dashboardData.theme || {};
+    dashboardData.theme[key] = v;
+    updateResetBtnState(key, v);
+    applyThemeToPreview();
+    if (!live) updateJsonOutput();
+  }
+}
+
+// Toggles the dimmed "is-default" state on a token's ↺ button — gives a visual
+// cue that there's nothing to reset when the value already matches the default.
+function updateResetBtnState(key, value) {
+  const tok = THEME_TOKENS.flatMap(g => g.items).find(t => t.key === key);
+  if (!tok) return;
+  const btn = document.querySelector(`.theme-reset-btn[onclick="resetThemeToken('${key}')"]`);
+  if (!btn) return;
+  const isDefault = (value || '').toLowerCase() === tok.default.toLowerCase();
+  btn.classList.toggle('is-default', isDefault);
+}
+
+function resetTheme() {
+  dashboardData.theme = {};
+  THEME_TOKENS.forEach(g => g.items.forEach(tok => {
+    dashboardData.theme[tok.key] = tok.default;
+  }));
+  renderThemeForm();
+  applyThemeToPreview();
+  updateJsonOutput();
+}
+
+// Resets a single token to its built-in default and refreshes the swatch, hex
+// field, preview, and JSON. Called by the per-row ↺ button.
+function resetThemeToken(key) {
+  const tok = THEME_TOKENS.flatMap(g => g.items).find(t => t.key === key);
+  if (!tok) return;
+  dashboardData.theme = dashboardData.theme || {};
+  dashboardData.theme[key] = tok.default;
+  const swatch = document.getElementById('themeSwatch_' + key);
+  const hex = document.getElementById('themeHex_' + key);
+  if (swatch) swatch.value = tok.default;
+  if (hex) hex.value = tok.default;
+  const btn = document.querySelector(`.theme-reset-btn[onclick="resetThemeToken('${key}')"]`);
+  if (btn) btn.classList.add('is-default');
+  applyThemeToPreview();
+  updateJsonOutput();
+}
+
+// Sets CSS variables on every .remote-screen so the preview (in-frame and
+// expanded modal — same node, moved around) picks them up. Called on every
+// theme edit and after initEditor/renderPreview.
+function applyThemeToPreview() {
+  const vals = themeValues();
+  const screens = document.querySelectorAll('.remote-screen');
+  screens.forEach(el => {
+    Object.keys(vals).forEach(key => {
+      el.style.setProperty('--' + cssVarFor(key), vals[key]);
+    });
+  });
+}
+
+// Maps camelCase token keys to the CSS variable names used in styles.css.
+function cssVarFor(key) {
+  const map = {
+    background: 'bg',
+    cardSurface: 'card',
+    insetSurface: 'inset',
+    controlBackground: 'control',
+    primaryText: 'text',
+    mutedText: 'muted',
+    iconTint: 'icon',
+    accent: 'accent',
+    accentSecondary: 'accent2',
+    amber: 'amber',
+    danger: 'danger',
+    success: 'success',
+  };
+  return map[key] || key;
+}
+
+// ---- Reusable color picker field for card color overrides -------------------
+//
+// Same swatch + hex + ↺ reset control as the theme form, but for per-card
+// color options (scene_grid item `color`, switch `on_color`). These support
+// ARGB (#AARRGGBB) — the <input type="color"> swatch only handles #RRGGBB, so
+// it shows the RGB part and preserves the alpha prefix from the hex field
+// when the swatch changes. Reset clears to empty (= use the built-in default).
+
+// Returns the #RRGGBB portion of an ARGB/RGB hex string for the swatch.
+function rgbPartOf(hex) {
+  if (!hex) return '#000000';
+  let s = hex.trim().replace(/^#/, '');
+  if (s.length === 8) s = s.slice(2);      // AARRGGBB -> RRGGBB
+  if (s.length === 6) return '#' + s;
+  return '#000000';
+}
+
+// Returns the alpha prefix (e.g. "66") from an #AARRGGBB string, or '' if
+// opaque / no alpha.
+function alphaPartOf(hex) {
+  if (!hex) return '';
+  let s = hex.trim().replace(/^#/, '');
+  return s.length === 8 ? s.slice(0, 2) : '';
+}
+
+// Generates HTML for a color picker row. `id` is a base id (e.g. 'giColor');
+// the swatch gets id `${id}Swatch`, the hex field gets `${id}Hex`.
+// `currentValue` is the existing hex string (may be empty). `placeholder`
+// is the default hex shown in the hex field + swatch when empty (e.g.
+// "#66009688" — the built-in color used when the override is not set).
+function colorFieldHtml(id, currentValue, placeholder) {
+  const v = (currentValue || '').trim();
+  const def = (placeholder || '').trim();
+  // Swatch shows the configured color, or the default's RGB part when empty
+  // — so an unconfigured field reads as "the default", not black.
+  const swatchVal = v ? rgbPartOf(v) : (def ? rgbPartOf(def) : '#000000');
+  const isEmpty = !v;
+  return `
+    <div class="theme-row theme-row-card">
+      <input type="color" class="theme-swatch" id="${id}Swatch" value="${swatchVal}" onchange="onColorFieldInput('${id}', this.value, '${def}')" oninput="onColorFieldInput('${id}', this.value, '${def}', true)">
+      <input type="text" class="theme-hex" id="${id}Hex" value="${v}" placeholder="${def}" onchange="onColorFieldHexInput('${id}', this.value, '${def}')" oninput="onColorFieldHexInput('${id}', this.value, '${def}', true)">
+      <button type="button" class="theme-reset-btn${isEmpty ? ' is-default' : ''}" id="${id}Reset" title="Reset to default" onclick="resetColorField('${id}', '${def}')">↺</button>
+    </div>`;
+}
+
+// Swatch changed -> preserve alpha from the hex field, update hex field.
+function onColorFieldInput(id, value, def, live) {
+  const hexInput = document.getElementById(id + 'Hex');
+  const existing = hexInput ? hexInput.value.trim() : '';
+  const alpha = alphaPartOf(existing) || alphaPartOf(def);
+  const newHex = '#' + (alpha ? alpha : '') + value.replace(/^#/, '').toLowerCase();
+  if (hexInput) hexInput.value = newHex;
+  updateColorFieldResetBtn(id, newHex);
+  if (!live) renderPreview();
+}
+
+// Hex text field changed -> update swatch to match (if valid). When cleared,
+// the swatch reverts to the default color (not black).
+function onColorFieldHexInput(id, value, def, live) {
+  let v = (value || '').trim();
+  if (v && v[0] !== '#') v = '#' + v;
+  if (!v || /^#[0-9A-Fa-f]{6}$/.test(v) || /^#[0-9A-Fa-f]{8}$/.test(v)) {
+    const swatch = document.getElementById(id + 'Swatch');
+    if (swatch) swatch.value = v ? rgbPartOf(v) : (def ? rgbPartOf(def) : '#000000');
+    updateColorFieldResetBtn(id, v);
+    if (!live) renderPreview();
+  }
+}
+
+// Reset button -> clear the field (empty = use built-in default). Swatch
+// reverts to the default color so it doesn't read as black.
+function resetColorField(id, def) {
+  const hexInput = document.getElementById(id + 'Hex');
+  const swatch = document.getElementById(id + 'Swatch');
+  if (hexInput) hexInput.value = '';
+  if (swatch) swatch.value = def ? rgbPartOf(def) : '#000000';
+  const btn = document.getElementById(id + 'Reset');
+  if (btn) btn.classList.add('is-default');
+  renderPreview();
+}
+
+// Toggles the dimmed "is-default" state on a card color field's ↺ button.
+function updateColorFieldResetBtn(id, value) {
+  const btn = document.getElementById(id + 'Reset');
+  if (!btn) return;
+  btn.classList.toggle('is-default', !value);
+}
+
+// Reads the current value of a card color field (the hex text field).
+function colorFieldValue(id) {
+  const el = document.getElementById(id + 'Hex');
+  return el ? el.value.trim() : '';
+}
+
+// Sets the value of a card color field (updates both swatch and hex). When
+// the value is empty, the swatch reverts to the default color (not black).
+function setColorFieldValue(id, value) {
+  const v = (value || '').trim();
+  const hexInput = document.getElementById(id + 'Hex');
+  const swatch = document.getElementById(id + 'Swatch');
+  if (hexInput) hexInput.value = v;
+  // Read the default from the placeholder so the swatch shows the right color.
+  const def = hexInput ? (hexInput.placeholder || '').trim() : '';
+  if (swatch) swatch.value = v ? rgbPartOf(v) : (def ? rgbPartOf(def) : '#000000');
+  updateColorFieldResetBtn(id, v);
+}
+

--- a/app/src/main/assets/docs/styles.css
+++ b/app/src/main/assets/docs/styles.css
@@ -156,7 +156,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   .remote-screen {
     width: 164px; height: 272px;
     overflow: hidden; border-radius: 4px;
-    background: #0d0f14; border: 1px solid #050608;
+    background: var(--bg); border: 1px solid #050608;
     cursor: zoom-in;
     display: flex; flex-direction: column;
   }
@@ -358,12 +358,12 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
     display: none;
   }
 
-  .preview-apple-remote, .preview-tv-remote { background: #161616; border-radius: 24px; padding: 20px; display: flex; flex-direction: column; align-items: center; gap: 18px; max-width: 260px; margin: 0 auto; }
-  .preview-trackpad { width: 160px; height: 160px; background: #232323; border-radius: 50%; position: relative; display: flex; align-items: center; justify-content: center; }
-  .preview-inner-select { width: 46px; height: 46px; background: #303030; border-radius: 50%; }
+  .preview-apple-remote, .preview-tv-remote { background: var(--card); border-radius: 24px; padding: 20px; display: flex; flex-direction: column; align-items: center; gap: 18px; max-width: 260px; margin: 0 auto; }
+  .preview-trackpad { width: 160px; height: 160px; background: var(--control); border-radius: 50%; position: relative; display: flex; align-items: center; justify-content: center; }
+  .preview-inner-select { width: 46px; height: 46px; background: var(--control); border-radius: 50%; opacity: 0.7; }
   .preview-row-buttons { display: flex; justify-content: space-around; width: 100%; gap: 10px; }
-  .preview-pill { background: #2a2a2a; border-radius: 50px; padding: 8px 16px; font-size: 12px; color: #e6e6e6; }
-  .preview-play-btn { width: 44px; height: 44px; background: #2a2a2a; border-radius: 50%; display: flex; align-items: center; justify-content: center; color: #e6e6e6; }
+  .preview-pill { background: var(--control); border-radius: 50px; padding: 8px 16px; font-size: 12px; color: var(--text); }
+  .preview-play-btn { width: 44px; height: 44px; background: var(--control); border-radius: 50%; display: flex; align-items: center; justify-content: center; color: var(--text); }
   .preview-grid { display: grid; gap: 8px; min-width: 0; }
   .preview-tile { background: #2a2a2a; border-radius: 8px; padding: 10px; font-size: 0.82rem; text-align: center; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; box-sizing: border-box; }
 
@@ -386,38 +386,38 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   }
   .preview-scene-tile.no-icon .st-label { font-size: 15px; margin-top: 0; }
   .preview-button-tile .bt-label {
-    color: #E6F0F1; font-size: 12px; font-weight: 500; text-align: center; max-width: 100%;
+    color: var(--text); font-size: 12px; font-weight: 500; text-align: center; max-width: 100%;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
-  .preview-button-tile.no-icon { background: #2A4954; }
-  .preview-button-tile.has-icon { background: #2A4954; }
+  .preview-button-tile.no-icon { background: var(--control); }
+  .preview-button-tile.has-icon { background: var(--control); }
   .preview-button-tile.no-icon .bt-label { font-size: 15px; }
 
   /* cover card — mirrors CoverCard.kt's 3 layouts (default / horizontal / vertical)[cite: 1] */
-  .preview-cover { border-radius: 18px; background: #1E3841; padding: 12px 14px; box-sizing: border-box; }
+  .preview-cover { border-radius: 18px; background: var(--card); padding: 12px 14px; box-sizing: border-box; }
   .preview-cover.layout-horizontal { display: flex; align-items: center; gap: 12px; }
   .preview-cover.layout-default { display: flex; flex-direction: column; gap: 12px; }
   .preview-cover.layout-vertical { display: flex; flex-direction: column; align-items: center; gap: 8px; }
-  .pc-icon { width: 42px; height: 42px; border-radius: 12px; background: #2A4954; display: flex; align-items: center; justify-content: center; flex: 0 0 auto; }
+  .pc-icon { width: 42px; height: 42px; border-radius: 12px; background: var(--control); display: flex; align-items: center; justify-content: center; flex: 0 0 auto; }
   .pc-icon.pc-icon-lg { width: 48px; height: 48px; }
-  .pc-icon svg { width: 24px; height: 24px; fill: #B6C9CE; }
+  .pc-icon svg { width: 24px; height: 24px; fill: var(--icon); }
   .pc-namestate { display: flex; flex-direction: column; min-width: 0; }
   .pc-namestate.pc-center { align-items: center; text-align: center; }
-  .pc-name { color: #E6F0F1; font-size: 16px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
-  .pc-state { color: #93AFB6; font-size: 13px; }
+  .pc-name { color: var(--text); font-size: 16px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+  .pc-state { color: var(--muted); font-size: 13px; }
   .pc-controls { display: flex; gap: 8px; }
   .pc-controls.pc-full { width: 100%; justify-content: space-evenly; }
-  .pc-btn { width: 44px; height: 44px; border-radius: 50%; background: #2C4C58; display: flex; align-items: center; justify-content: center; flex: 0 0 auto; }
-  .pc-btn svg { width: 24px; height: 24px; fill: #CBDCE0; }
+  .pc-btn { width: 44px; height: 44px; border-radius: 50%; background: var(--control); display: flex; align-items: center; justify-content: center; flex: 0 0 auto; }
+  .pc-btn svg { width: 24px; height: 24px; fill: var(--icon); }
   .pc-btn.pc-disabled { opacity: 0.35; }
   /* Mushroom-style draggable slider (position/tilt/brightness) — mirrors CoverCard.kt's
      and LightCard.kt's PercentSlider composable, static (non-interactive) in this preview.[cite: 1] */
-  .pc-slider { position: relative; width: 100%; height: 36px; border-radius: 18px; background: #152B33; overflow: hidden; box-sizing: border-box; display: flex; align-items: center; justify-content: center; }
+  .pc-slider { position: relative; width: 100%; height: 36px; border-radius: 18px; background: var(--inset); overflow: hidden; box-sizing: border-box; display: flex; align-items: center; justify-content: center; }
   .pc-slider-fill { position: absolute; left: 0; top: 0; bottom: 0; border-radius: 18px; }
-  .pc-slider-label { position: relative; color: #E6F0F1; font-size: 13px; font-weight: 600; z-index: 1; }
-  .pc-cycle-btn { width: 36px; height: 36px; border-radius: 50%; background: #2C4C58; display: flex; align-items: center; justify-content: center; flex: 0 0 auto; cursor: help; }
-  .pc-cycle-btn svg { width: 22px; height: 22px; fill: #CBDCE0; }
-  .preview-light { border-radius: 18px; background: #1E3841; padding: 12px 14px; box-sizing: border-box; }
+  .pc-slider-label { position: relative; color: var(--text); font-size: 13px; font-weight: 600; z-index: 1; }
+  .pc-cycle-btn { width: 36px; height: 36px; border-radius: 50%; background: var(--control); display: flex; align-items: center; justify-content: center; flex: 0 0 auto; cursor: help; }
+  .pc-cycle-btn svg { width: 22px; height: 22px; fill: var(--icon); }
+  .preview-light { border-radius: 18px; background: var(--card); padding: 12px 14px; box-sizing: border-box; }
   .preview-light.layout-horizontal { display: flex; align-items: center; gap: 12px; }
   .preview-light.layout-default { display: flex; flex-direction: column; gap: 10px; }
   .preview-light.layout-vertical { display: flex; flex-direction: column; align-items: center; gap: 8px; }
@@ -427,77 +427,114 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   .pl-swatch { width: 28px; height: 28px; border-radius: 50%; flex: 0 0 auto; box-shadow: 0 0 0 1px rgba(255,255,255,0.15) inset; }
 
   /* media_player card — mirrors MediaPlayerCard.kt's compact Mushroom-style tile[cite: 1] */
-  .preview-media { border-radius: 18px; background: #1E3841; padding: 12px 14px; box-sizing: border-box; display: flex; flex-direction: column; gap: 10px; }
+  .preview-media { border-radius: 18px; background: var(--card); padding: 12px 14px; box-sizing: border-box; display: flex; flex-direction: column; gap: 10px; }
   .pm-row { display: flex; align-items: center; gap: 12px; }
-  .pm-avatar { width: 42px; height: 42px; border-radius: 50%; background: #2A4954; display: flex; align-items: center; justify-content: center; flex: 0 0 auto; overflow: hidden; }
-  .pm-avatar svg { width: 22px; height: 22px; fill: #B6C9CE; }
+  .pm-avatar { width: 42px; height: 42px; border-radius: 50%; background: var(--control); display: flex; align-items: center; justify-content: center; flex: 0 0 auto; overflow: hidden; }
+  .pm-avatar svg { width: 22px; height: 22px; fill: var(--icon); }
   .pm-controls { display: flex; align-items: center; gap: 8px; }
-  .pm-btn { width: 36px; height: 36px; border-radius: 10px; background: #23414B; display: flex; align-items: center; justify-content: center; flex: 0 0 auto; }
-  .pm-btn.pm-accent { background: #4C6EF5; }
-  .pm-btn svg { width: 18px; height: 18px; fill: #E6F0F1; }
+  .pm-btn { width: 36px; height: 36px; border-radius: 10px; background: var(--control); display: flex; align-items: center; justify-content: center; flex: 0 0 auto; }
+  .pm-btn.pm-accent { background: var(--accent2); }
+  .pm-btn svg { width: 18px; height: 18px; fill: var(--text); }
   .pm-btn.pm-swap { margin-left: auto; }
-  .preview-media-full { border-radius: 20px; background: #1B343D; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; align-items: center; gap: 14px; }
-  .pm-art { width: 100%; aspect-ratio: 1.2; border-radius: 16px; background: #3A2E5A; background-size: cover; background-position: center; display: flex; align-items: center; justify-content: center; }
+  .preview-media-full { border-radius: 20px; background: var(--card); padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; align-items: center; gap: 14px; }
+  .pm-art { width: 100%; aspect-ratio: 1.2; border-radius: 16px; background: var(--control); background-size: cover; background-position: center; display: flex; align-items: center; justify-content: center; }
   .pm-art svg { width: 48px; height: 48px; fill: rgba(255,255,255,0.6); }
-  .pm-full-title { color: #F1F4FA; font-size: 20px; font-weight: 700; text-align: center; }
-  .pm-full-subtitle { color: #B6BECC; font-size: 14px; text-align: center; }
+  .pm-full-title { color: var(--text); font-size: 20px; font-weight: 700; text-align: center; }
+  .pm-full-subtitle { color: var(--muted); font-size: 14px; text-align: center; }
   .pm-progress { width: 100%; height: 4px; border-radius: 2px; background: rgba(255,255,255,0.2); overflow: hidden; }
-  .pm-progress-fill { height: 100%; background: #4C6EF5; }
+  .pm-progress-fill { height: 100%; background: var(--accent2); }
   .pm-full-controls { display: flex; justify-content: space-evenly; align-items: center; width: 100%; }
-  .pm-full-btn { width: 50px; height: 50px; border-radius: 50%; background: rgba(44,76,88,0.35); display: flex; align-items: center; justify-content: center; }
+  .pm-full-btn { width: 50px; height: 50px; border-radius: 50%; background: var(--control); display: flex; align-items: center; justify-content: center; opacity: 0.6; }
   .pm-full-btn.pm-big { width: 64px; height: 64px; }
-  .pm-full-btn.pm-accent { background: #4C6EF5; }
+  .pm-full-btn.pm-accent { background: var(--accent2); opacity: 1; }
   .pm-full-btn svg { width: 24px; height: 24px; fill: #fff; }
 
-  .preview-clock-weather { background: #1B343D; border-radius: 18px; padding: 12px; display: flex; align-items: center; gap: 12px; }
+  .preview-clock-weather { background: var(--card); border-radius: 18px; padding: 12px; display: flex; align-items: center; gap: 12px; }
   .preview-clock-weather .cw-emoji { font-size: 34px; }
-  .preview-clock-weather .cw-time { color: #F2F5FA; font-size: 26px; font-weight: 300; line-height: 1.1; }
-  .preview-clock-weather .cw-date { color: #9AB0C4; font-size: 12px; }
-  .preview-clock-weather .cw-right { text-align: right; color: #9AB0C4; font-size: 11px; }
-  .preview-clock-weather .cw-temp { color: #F2F5FA; font-size: 20px; font-weight: 600; }
+  .preview-clock-weather .cw-time { color: var(--text); font-size: 26px; font-weight: 300; line-height: 1.1; }
+  .preview-clock-weather .cw-date { color: var(--muted); font-size: 12px; }
+  .preview-clock-weather .cw-right { text-align: right; color: var(--muted); font-size: 11px; }
+  .preview-clock-weather .cw-temp { color: var(--text); font-size: 20px; font-weight: 600; }
   .preview-clock-weather-wrap { display: flex; flex-direction: column; gap: 8px; }
-  .cw-forecast-row { display: flex; align-items: center; gap: 8px; font-size: 12px; color: #9AB0C4; }
+  .cw-forecast-row { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--muted); }
   .cw-forecast-row .cw-fday { width: 34px; }
   .cw-forecast-row .cw-femoji { width: 22px; text-align: center; }
   .cw-forecast-row .cw-flow { width: 30px; text-align: right; }
-  .cw-forecast-row .cw-fhigh { width: 30px; text-align: right; color: #F2F5FA; font-weight: 600; }
-  .cw-forecast-row .cw-fbar { flex: 1; height: 6px; border-radius: 3px; background: #2C3E4E; position: relative; overflow: hidden; }
-  .cw-forecast-row .cw-fbar-fill { position: absolute; top: 0; bottom: 0; background: linear-gradient(90deg, #3DD68C, #9BE7C4); border-radius: 3px; }
+  .cw-forecast-row .cw-fhigh { width: 30px; text-align: right; color: var(--text); font-weight: 600; }
+  .cw-forecast-row .cw-fbar { flex: 1; height: 6px; border-radius: 3px; background: var(--control); position: relative; overflow: hidden; }
+  .cw-forecast-row .cw-fbar-fill { position: absolute; top: 0; bottom: 0; background: linear-gradient(90deg, var(--success), var(--amber)); border-radius: 3px; }
 
-  .preview-vacuum { background: #1B343D; border-radius: 20px; padding: 14px; }
-  .preview-vacuum .vc-header { display: flex; align-items: center; justify-content: space-between; font-size: 13px; color: #93AFB6; }
-  .preview-vacuum .vc-name { color: #E6F0F1; font-size: 16px; font-weight: 600; }
+  .preview-vacuum { background: var(--card); border-radius: 20px; padding: 14px; }
+  .preview-vacuum .vc-header { display: flex; align-items: center; justify-content: space-between; font-size: 13px; color: var(--muted); }
+  .preview-vacuum .vc-name { color: var(--text); font-size: 16px; font-weight: 600; }
   .preview-vacuum .vc-rooms { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
-  .preview-vacuum .vc-room { background: #2A4954; color: #E6F0F1; border-radius: 10px; padding: 6px 10px; font-size: 12px; }
+  .preview-vacuum .vc-room { background: var(--control); color: var(--text); border-radius: 10px; padding: 6px 10px; font-size: 12px; }
 
-  .preview-climate { background: #1B343D; border-radius: 16px; padding: 12px; color: #E6F0F1; }
+  .preview-climate { background: var(--card); border-radius: 16px; padding: 12px; color: var(--text); }
   .preview-climate .cc-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
   .preview-climate .cc-name { font-size: 14px; font-weight: 600; }
-  .preview-climate .cc-power { width: 26px; height: 26px; border-radius: 50%; background: #1E3A2E; color: #9BE7C4; display: flex; align-items: center; justify-content: center; }
-  .preview-climate .cc-power.is-off { background: #3A2E2E; color: #E06767; }
+  .preview-climate .cc-power { width: 26px; height: 26px; border-radius: 50%; background: var(--success); color: #fff; display: flex; align-items: center; justify-content: center; }
+  .preview-climate .cc-power.is-off { background: var(--danger); color: #fff; }
   .preview-climate .cc-temp-row { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
-  .preview-climate .cc-stepper { width: 34px; height: 34px; border-radius: 50%; background: #2C4C58; display: flex; align-items: center; justify-content: center; color: #CBDCE0; font-size: 18px; flex-shrink: 0; }
+  .preview-climate .cc-stepper { width: 34px; height: 34px; border-radius: 50%; background: var(--control); display: flex; align-items: center; justify-content: center; color: var(--icon); font-size: 18px; flex-shrink: 0; }
   .preview-climate .cc-temp-col { text-align: center; }
   .preview-climate .cc-temp { font-size: 26px; font-weight: 700; }
-  .preview-climate .cc-current { font-size: 11px; color: #93AFB6; }
-  .preview-climate .cc-caption { font-size: 10px; color: #6D8891; font-weight: 600; margin: 6px 0 3px; }
+  .preview-climate .cc-temp-range { font-size: 22px; }
+  .preview-climate .cc-current { font-size: 11px; color: var(--muted); }
+  .preview-climate .cc-caption { font-size: 10px; color: var(--muted); font-weight: 600; margin: 6px 0 3px; }
   .preview-climate .cc-row { display: flex; gap: 5px; margin-bottom: 5px; }
-  .preview-climate .cc-chip { flex: 1; height: 28px; border-radius: 8px; background: #23414B; color: #93AFB6; display: flex; align-items: center; justify-content: center; font-size: 11px; }
-  .preview-climate .cc-chip-selected { background: #4C6EF5; color: #fff; }
+  .preview-climate .cc-chip { flex: 1; height: 28px; border-radius: 8px; background: var(--control); color: var(--muted); display: flex; align-items: center; justify-content: center; font-size: 11px; }
+  .preview-climate .cc-chip-selected { background: var(--accent2); color: #fff; }
   .preview-climate .cc-chip svg { width: 16px; height: 16px; }
 
-  .preview-fan { background: #1B343D; border-radius: 16px; padding: 12px; color: #E6F0F1; }
+  .preview-fan { background: var(--card); border-radius: 16px; padding: 12px; color: var(--text); }
   .preview-fan .fx-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
   .preview-fan .fx-name { font-size: 14px; font-weight: 600; }
-  .preview-fan .fx-power { width: 26px; height: 26px; border-radius: 50%; background: #1E3A2E; color: #9BE7C4; display: flex; align-items: center; justify-content: center; font-size: 13px; }
-  .preview-fan .fx-power.is-off { background: #3A2E2E; color: #E06767; }
-  .preview-fan .fx-caption { font-size: 10px; color: #6D8891; font-weight: 600; margin: 6px 0 3px; }
+  .preview-fan .fx-power { width: 26px; height: 26px; border-radius: 50%; background: var(--success); color: #fff; display: flex; align-items: center; justify-content: center; font-size: 13px; }
+  .preview-fan .fx-power.is-off { background: var(--danger); color: #fff; }
+  .preview-fan .fx-caption { font-size: 10px; color: var(--muted); font-weight: 600; margin: 6px 0 3px; }
   .preview-fan .fx-row { display: flex; gap: 5px; margin-bottom: 5px; }
-  .preview-fan .fx-chip { flex: 1; height: 28px; border-radius: 8px; background: #23414B; color: #93AFB6; display: flex; align-items: center; justify-content: center; font-size: 11px; }
-  .preview-fan .fx-chip-selected { background: #4C6EF5; color: #fff; }
+  .preview-fan .fx-chip { flex: 1; height: 28px; border-radius: 8px; background: var(--control); color: var(--muted); display: flex; align-items: center; justify-content: center; font-size: 11px; }
+  .preview-fan .fx-chip-selected { background: var(--accent2); color: #fff; }
   .preview-fan .fx-pct-row { display: flex; align-items: center; justify-content: space-between; }
-  .preview-fan .fx-pct-btn { width: 30px; height: 30px; border-radius: 50%; background: #2C4C58; display: flex; align-items: center; justify-content: center; color: #CBDCE0; }
+  .preview-fan .fx-pct-btn { width: 30px; height: 30px; border-radius: 50%; background: var(--control); display: flex; align-items: center; justify-content: center; color: var(--icon); }
   .preview-fan .fx-pct { font-size: 16px; font-weight: 600; }
-  .preview-fan-simple { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-radius: 18px; background: #2B3A67; }
+  .preview-fan-simple { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-radius: 18px; background: var(--control); }
   .preview-fan-simple .fs-name { font-size: 15px; font-weight: 600; }
-  .preview-fan-simple .fs-state { font-size: 12px; color: #93AFB6; }
+  .preview-fan-simple .fs-state { font-size: 12px; color: var(--muted); }
+
+  /* Entity autocomplete dropdown — attached to Entity ID inputs in the card
+     edit form by attachEntityAutocomplete() in preview.js. Floats below the
+     input, same width, dark theme to match the editor. */
+  .ea-dropdown { position: fixed; z-index: 9999; background: #2d2d2d; border: 1px solid #444; border-radius: 6px; max-height: 260px; overflow-y: auto; box-shadow: 0 6px 18px rgba(0,0,0,0.5); }
+  .ea-item { display: flex; justify-content: space-between; align-items: center; padding: 6px 10px; cursor: pointer; font-size: 0.82rem; gap: 8px; }
+  .ea-item:hover { background: #383838; }
+  .ea-item.ea-selected { background: #00E5FF; color: #121212; }
+  .ea-item.ea-selected .ea-name { color: #333; }
+  .ea-id { font-family: monospace; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .ea-name { color: #888; font-size: 0.78rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex-shrink: 0; max-width: 45%; }
+  .ea-more { padding: 4px 10px; font-size: 0.75rem; color: #666; font-style: italic; }
+
+  /* ---- Theme & Colors form ---- */
+  .theme-group-label { font-size: 0.72rem; font-weight: 700; color: #00E5FF; text-transform: uppercase; letter-spacing: 0.5px; margin: 12px 0 4px; }
+  .theme-group-label:first-child { margin-top: 0; }
+  .theme-row { display: flex; align-items: center; gap: 8px; margin: 5px 0; }
+  .theme-swatch { width: 34px !important; height: 34px; min-width: 34px; padding: 2px; border: 1px solid #444; border-radius: 6px; background: #2d2d2d; cursor: pointer; flex: 0 0 auto; }
+  .theme-hex { width: 90px; flex: 0 0 auto; font-family: monospace; text-transform: uppercase; }
+  .theme-token-label { margin: 0; font-size: 0.8rem; color: #ccc; flex: 1; min-width: 0; }
+  .theme-reset-btn { flex: 0 0 auto; width: 28px; height: 28px; min-width: 28px; padding: 0; margin: 0; background: #2d2d2d; color: #aaa; border: 1px solid #444; border-radius: 6px; font-size: 1rem; line-height: 1; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+  .theme-reset-btn:hover { background: #383838; color: #fff; }
+  .theme-reset-btn.is-default { opacity: 0.3; cursor: default; }
+  .theme-reset-btn.is-default:hover { background: #2d2d2d; color: #aaa; }
+  /* Card editor variant: no label, so the hex field flexes to fill width. */
+  .theme-row-card .theme-hex { flex: 1 1 auto; width: auto; }
+
+  /* ---- Theme CSS variables (preview surface) ----
+     Defaults match the app's compiled-in ThemeConfig. Overridden at runtime
+     by applyThemeToPreview() in theme.js, which sets these on .remote-screen. */
+  .remote-screen {
+    --bg: #0E2229; --card: #1B343D; --inset: #152B33; --control: #2C4C58;
+    --text: #E6F0F1; --muted: #93AFB6; --icon: #CBDCE0;
+    --accent: #6EA8FE; --accent2: #4C6EF5; --amber: #FFC24B;
+    --danger: #E06767; --success: #4CAF50;
+  }

--- a/app/src/main/java/com/custom/astrion/cards/Card.kt
+++ b/app/src/main/java/com/custom/astrion/cards/Card.kt
@@ -6,6 +6,7 @@ import com.custom.astrion.config.ActivityRuntime
 import com.custom.astrion.config.IrDeviceConfig
 import com.custom.astrion.ha.EntityMap
 import com.custom.astrion.ha.HaClient
+import com.custom.astrion.ui.ThemeColors
 
 /**
  * THE EXTENSIBILITY CORE.
@@ -82,6 +83,10 @@ class CardContext(
      * `track: true`, or `activity`) call into this after firing their own
      * action; an "active activities" overlay reads from it directly. */
     val activityRuntime: ActivityRuntime? = null,
+    /** Resolved theme colors for this dashboard. Cards read from here instead
+     * of hardcoded Color literals. Defaults to the original palette so cards
+     * render correctly even without a provider (e.g. in previews/tests). */
+    val theme: ThemeColors = com.custom.astrion.ui.ThemeColors.Default,
 )
 
 /**

--- a/app/src/main/java/com/custom/astrion/cards/impl/AppleTvRemoteCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/AppleTvRemoteCard.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.sp
 import com.custom.astrion.cards.CardConfig
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
+import com.custom.astrion.ui.ThemeColors
 
 /**
  * Apple TV remote styled like a Siri Remote.
@@ -71,7 +72,7 @@ class AppleTvRemoteCard : CardRenderer {
                 Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(24.dp))
-                    .background(Color(0xFF161616))
+                    .background(ctx.theme.cardSurface)
                     .padding(20.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(18.dp),
@@ -82,14 +83,15 @@ class AppleTvRemoteCard : CardRenderer {
                 onLeft = { send("DirectionLeft") },
                 onRight = { send("DirectionRight") },
                 onSelect = { send("Select") },
+                theme = ctx.theme,
             )
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceEvenly,
             ) {
-                PillButton(icon = Icons.Filled.Menu, label = "Menu") { send("Menu") }
-                PillButton(label = "Home") { send("Home") }
+                PillButton(icon = Icons.Filled.Menu, label = "Menu", theme = ctx.theme) { send("Menu") }
+                PillButton(label = "Home", theme = ctx.theme) { send("Home") }
             }
 
             Box(
@@ -97,7 +99,7 @@ class AppleTvRemoteCard : CardRenderer {
                     Modifier
                         .size(56.dp)
                         .clip(CircleShape)
-                        .background(Color(0xFF2A2A2A))
+                        .background(ctx.theme.controlBackground)
                         .clickable {
                             send(if (isPlaying) "Pause" else "Play")
                             isPlaying = !isPlaying
@@ -107,7 +109,7 @@ class AppleTvRemoteCard : CardRenderer {
                 Icon(
                     if (isPlaying) Icons.Filled.Pause else Icons.Filled.PlayArrow,
                     contentDescription = null,
-                    tint = Color(0xFFE6E6E6),
+                    tint = ctx.theme.primaryText,
                 )
             }
         }
@@ -120,26 +122,27 @@ class AppleTvRemoteCard : CardRenderer {
         onLeft: () -> Unit,
         onRight: () -> Unit,
         onSelect: () -> Unit,
+        theme: ThemeColors,
     ) {
         Box(
             modifier =
                 Modifier
                     .size(220.dp)
                     .clip(CircleShape)
-                    .background(Color(0xFF232323))
+                    .background(theme.controlBackground)
                     .clickable(onClick = onSelect),
             contentAlignment = Alignment.Center,
         ) {
-            EdgeIcon(Icons.Filled.KeyboardArrowUp, Alignment.TopCenter, onUp)
-            EdgeIcon(Icons.Filled.KeyboardArrowDown, Alignment.BottomCenter, onDown)
-            EdgeIcon(Icons.AutoMirrored.Filled.KeyboardArrowLeft, Alignment.CenterStart, onLeft)
-            EdgeIcon(Icons.AutoMirrored.Filled.KeyboardArrowRight, Alignment.CenterEnd, onRight)
+            EdgeIcon(Icons.Filled.KeyboardArrowUp, Alignment.TopCenter, onUp, theme)
+            EdgeIcon(Icons.Filled.KeyboardArrowDown, Alignment.BottomCenter, onDown, theme)
+            EdgeIcon(Icons.AutoMirrored.Filled.KeyboardArrowLeft, Alignment.CenterStart, onLeft, theme)
+            EdgeIcon(Icons.AutoMirrored.Filled.KeyboardArrowRight, Alignment.CenterEnd, onRight, theme)
             Box(
                 modifier =
                     Modifier
                         .size(64.dp)
                         .clip(CircleShape)
-                        .background(Color(0xFF303030)),
+                        .background(theme.controlBackground),
             )
         }
     }
@@ -149,6 +152,7 @@ class AppleTvRemoteCard : CardRenderer {
         icon: ImageVector,
         align: Alignment,
         onClick: () -> Unit,
+        theme: ThemeColors,
     ) {
         Box(
             modifier =
@@ -165,7 +169,7 @@ class AppleTvRemoteCard : CardRenderer {
                         .clickable(onClick = onClick),
                 contentAlignment = Alignment.Center,
             ) {
-                Icon(icon, contentDescription = null, tint = Color(0xFF9A9A9A))
+                Icon(icon, contentDescription = null, tint = theme.mutedText)
             }
         }
     }
@@ -174,20 +178,21 @@ class AppleTvRemoteCard : CardRenderer {
     private fun PillButton(
         icon: ImageVector? = null,
         label: String,
+        theme: ThemeColors,
         onClick: () -> Unit,
     ) {
         Row(
             modifier =
                 Modifier
                     .clip(RoundedCornerShape(50))
-                    .background(Color(0xFF2A2A2A))
+                    .background(theme.controlBackground)
                     .clickable(onClick = onClick)
                     .padding(horizontal = 18.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(6.dp),
         ) {
-            icon?.let { Icon(it, contentDescription = null, tint = Color(0xFFE6E6E6)) }
-            Text(label, color = Color(0xFFE6E6E6), fontSize = 13.sp, fontWeight = FontWeight.Medium)
+            icon?.let { Icon(it, contentDescription = null, tint = theme.primaryText) }
+            Text(label, color = theme.primaryText, fontSize = 13.sp, fontWeight = FontWeight.Medium)
         }
     }
 }

--- a/app/src/main/java/com/custom/astrion/cards/impl/ButtonGridCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/ButtonGridCard.kt
@@ -23,6 +23,7 @@ import com.custom.astrion.cards.CardConfig
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.ThemeColors
 import java.io.File
 
 /**
@@ -63,7 +64,7 @@ class ButtonGridCard : CardRenderer {
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
                     row.forEach { b ->
-                        GridButton(b, Modifier.weight(1f)) { fire(ctx, b) }
+                        GridButton(b, Modifier.weight(1f), ctx.theme) { fire(ctx, b) }
                     }
                     repeat(columns - row.size) { Spacer(Modifier.weight(1f)) }
                 }
@@ -90,6 +91,7 @@ class ButtonGridCard : CardRenderer {
     private fun GridButton(
         b: Map<String, Any?>,
         modifier: Modifier,
+        theme: ThemeColors,
         onClick: () -> Unit,
     ) {
         val name = b["name"] as? String
@@ -110,7 +112,7 @@ class ButtonGridCard : CardRenderer {
                 modifier
                     .height(if (hasIcon) 68.dp else 48.dp)
                     .clip(RoundedCornerShape(14.dp))
-                    .background(Color(0xFF2A4954))
+                    .background(theme.controlBackground)
                     .clickable(onClick = onClick)
                     .padding(6.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -123,7 +125,7 @@ class ButtonGridCard : CardRenderer {
             if (!name.isNullOrBlank()) {
                 Text(
                     name,
-                    color = Color(0xFFE6F0F1),
+                    color = theme.primaryText,
                     fontSize = if (hasIcon) 12.sp else 15.sp,
                     fontWeight = FontWeight.Medium,
                     maxLines = 1,

--- a/app/src/main/java/com/custom/astrion/cards/impl/ClimateCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/ClimateCard.kt
@@ -34,6 +34,7 @@ import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.HaLabels
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.ThemeColors
 import com.custom.astrion.ui.icons.MdiIcons
 
 /**
@@ -165,7 +166,7 @@ class ClimateCard : CardRenderer {
                 Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(20.dp))
-                    .background(Color(0xFF1B343D))
+                    .background(ctx.theme.cardSurface)
                     .padding(14.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
@@ -175,20 +176,20 @@ class ClimateCard : CardRenderer {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(name, color = Color(0xFFE6F0F1), fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
+                Text(name, color = ctx.theme.primaryText, fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
                 Box(
                     modifier =
                         Modifier
                             .size(36.dp)
                             .clip(CircleShape)
-                            .background(if (isOff) Color(0xFF3A2E2E) else Color(0xFF2C4C58))
+                            .background(if (isOff) ctx.theme.danger.copy(alpha = 0.25f) else ctx.theme.controlBackground)
                             .clickable { turnOff() },
                     contentAlignment = Alignment.Center,
                 ) {
                     Icon(
                         Icons.Filled.PowerSettingsNew,
                         contentDescription = "Off",
-                        tint = if (isOff) Color(0xFFE06767) else Color(0xFFCBDCE0),
+                        tint = if (isOff) ctx.theme.danger else ctx.theme.iconTint,
                         modifier = Modifier.size(20.dp),
                     )
                 }
@@ -200,28 +201,28 @@ class ClimateCard : CardRenderer {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Stepper(Icons.Filled.Remove) { target?.let { setTemp(it - step) } }
+                Stepper(Icons.Filled.Remove, ctx.theme) { target?.let { setTemp(it - step) } }
 
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(
                         target?.let { "${trim(it)}°" } ?: "—",
-                        color = Color(0xFFE6F0F1),
+                        color = ctx.theme.primaryText,
                         fontSize = 36.sp,
                         fontWeight = FontWeight.Bold,
                     )
                     Text(
                         current?.let { stringResource(R.string.climate_current_temp, trim(it)) } ?: "",
-                        color = Color(0xFF93AFB6),
+                        color = ctx.theme.mutedText,
                         fontSize = 12.sp,
                     )
                 }
 
-                Stepper(Icons.Filled.Add) { target?.let { setTemp(it + step) } }
+                Stepper(Icons.Filled.Add, ctx.theme) { target?.let { setTemp(it + step) } }
             }
 
             // HVAC mode chips (icons by default, matching HA's tile card; "off" excluded, see above).
             if (modes.isNotEmpty()) {
-                ModeSection(caption = if (showCaptions) stringResource(R.string.climate_hvac_caption) else null) {
+                ModeSection(caption = if (showCaptions) stringResource(R.string.climate_hvac_caption) else null, theme = ctx.theme) {
                     balancedRows(modes, maxPerRow = if (hvacModeIcons) 5 else 3).forEach { row ->
                         Row(
                             modifier = Modifier.fillMaxWidth(),
@@ -232,6 +233,7 @@ class ClimateCard : CardRenderer {
                                     label = HaLabels.hvacMode(m),
                                     icon = if (hvacModeIcons) hvacModeIcon(m) else null,
                                     selected = m == mode,
+                                    theme = ctx.theme,
                                     modifier = Modifier.weight(1f),
                                 ) { setMode(m) }
                             }
@@ -242,7 +244,7 @@ class ClimateCard : CardRenderer {
 
             // Fan mode chips
             if (fanModes.isNotEmpty()) {
-                ModeSection(caption = if (showCaptions) stringResource(R.string.climate_fan_caption) else null) {
+                ModeSection(caption = if (showCaptions) stringResource(R.string.climate_fan_caption) else null, theme = ctx.theme) {
                     balancedRows(fanModes, maxPerRow = if (fanModeIcons) 5 else 3).forEach { row ->
                         Row(
                             modifier = Modifier.fillMaxWidth(),
@@ -253,6 +255,7 @@ class ClimateCard : CardRenderer {
                                     label = HaLabels.fanMode(f),
                                     icon = if (fanModeIcons) fanModeIcon(f) else null,
                                     selected = fanMode?.equals(f, ignoreCase = true) == true,
+                                    theme = ctx.theme,
                                     modifier = Modifier.weight(1f),
                                 ) { setFan(f) }
                             }
@@ -263,7 +266,7 @@ class ClimateCard : CardRenderer {
 
             // Swing mode chips
             if (swingModes.isNotEmpty()) {
-                ModeSection(caption = if (showCaptions) stringResource(R.string.climate_swing_caption) else null) {
+                ModeSection(caption = if (showCaptions) stringResource(R.string.climate_swing_caption) else null, theme = ctx.theme) {
                     balancedRows(swingModes, maxPerRow = if (swingModeIcons) 5 else 3).forEach { row ->
                         Row(
                             modifier = Modifier.fillMaxWidth(),
@@ -274,6 +277,7 @@ class ClimateCard : CardRenderer {
                                     label = HaLabels.swingMode(s),
                                     icon = if (swingModeIcons) swingModeIcon(s) else null,
                                     selected = swingMode?.equals(s, ignoreCase = true) == true,
+                                    theme = ctx.theme,
                                     modifier = Modifier.weight(1f),
                                 ) { setSwing(s) }
                             }
@@ -343,6 +347,7 @@ class ClimateCard : CardRenderer {
     @Composable
     private fun Stepper(
         icon: ImageVector,
+        theme: ThemeColors,
         onClick: () -> Unit,
     ) {
         Box(
@@ -350,24 +355,25 @@ class ClimateCard : CardRenderer {
                 Modifier
                     .size(46.dp)
                     .clip(CircleShape)
-                    .background(Color(0xFF2C4C58))
+                    .background(theme.controlBackground)
                     .clickable(onClick = onClick),
             contentAlignment = Alignment.Center,
         ) {
-            Icon(icon, contentDescription = null, tint = Color(0xFFCBDCE0))
+            Icon(icon, contentDescription = null, tint = theme.iconTint)
         }
     }
 
     @Composable
     private fun ModeSection(
         caption: String?,
+        theme: ThemeColors,
         content: @Composable () -> Unit,
     ) {
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
             if (caption != null) {
                 Text(
                     caption,
-                    color = Color(0xFF6D8891),
+                    color = theme.mutedText,
                     fontSize = 11.sp,
                     fontWeight = FontWeight.Medium,
                 )
@@ -383,6 +389,7 @@ class ClimateCard : CardRenderer {
         label: String,
         selected: Boolean,
         modifier: Modifier,
+        theme: ThemeColors,
         icon: ImageVector? = null,
         onClick: () -> Unit,
     ) {
@@ -391,11 +398,11 @@ class ClimateCard : CardRenderer {
                 modifier
                     .height(34.dp)
                     .clip(RoundedCornerShape(10.dp))
-                    .background(if (selected) Color(0xFF4C6EF5) else Color(0xFF23414B))
+                    .background(if (selected) theme.accentSecondary else theme.controlBackground)
                     .clickable(onClick = onClick),
             contentAlignment = Alignment.Center,
         ) {
-            val tint = if (selected) Color.White else Color(0xFF93AFB6)
+            val tint = if (selected) Color.White else theme.mutedText
             if (icon != null) {
                 Icon(icon, contentDescription = label, tint = tint, modifier = Modifier.size(18.dp))
             } else {

--- a/app/src/main/java/com/custom/astrion/cards/impl/ClockWeatherCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/ClockWeatherCard.kt
@@ -24,6 +24,7 @@ import com.custom.astrion.cards.CardConfig
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.HaLabels
+import com.custom.astrion.ui.ThemeColors
 import kotlinx.coroutines.delay
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -105,7 +106,7 @@ class ClockWeatherCard : CardRenderer {
                 Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(18.dp))
-                    .background(Color(0xFF1B343D))
+                    .background(ctx.theme.cardSurface)
                     .padding(12.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
@@ -116,15 +117,15 @@ class ClockWeatherCard : CardRenderer {
                 Column(Modifier.weight(1f)) {
                     Text(
                         timeFmt.format(Date(now)),
-                        color = Color(0xFFF2F5FA),
+                        color = ctx.theme.primaryText,
                         fontSize = 32.sp,
                         fontWeight = FontWeight.Light,
                     )
-                    Text(dateFmt.format(Date(now)), color = Color(0xFF9AB0C4), fontSize = 13.sp)
+                    Text(dateFmt.format(Date(now)), color = ctx.theme.mutedText, fontSize = 13.sp)
                     if (todayEvent != null) {
                         Text(
                             todayEvent,
-                            color = Color(0xFF6EA8FE),
+                            color = ctx.theme.accent,
                             fontSize = 11.sp,
                             maxLines = 1,
                             overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
@@ -134,13 +135,13 @@ class ClockWeatherCard : CardRenderer {
                 Column(horizontalAlignment = Alignment.End) {
                     Text(
                         temp?.let { "${trim(it)}°" } ?: "—",
-                        color = Color(0xFFF2F5FA),
+                        color = ctx.theme.primaryText,
                         fontSize = 22.sp,
                         fontWeight = FontWeight.SemiBold,
                     )
                     Text(
                         HaLabels.weatherCondition(condition),
-                        color = Color(0xFF9AB0C4),
+                        color = ctx.theme.mutedText,
                         fontSize = 11.sp,
                     )
                 }
@@ -155,7 +156,7 @@ class ClockWeatherCard : CardRenderer {
                 val span = (weekMax - weekMin).coerceAtLeast(1.0)
 
                 Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                    shown.forEach { f -> ForecastRow(f, weekMin, span) }
+                    shown.forEach { f -> ForecastRow(f, weekMin, span, ctx.theme) }
                 }
             }
         }
@@ -166,6 +167,7 @@ class ClockWeatherCard : CardRenderer {
         f: Forecast,
         weekMin: Double,
         span: Double,
+        theme: ThemeColors,
     ) {
         val lowFrac = (((f.low ?: weekMin) - weekMin) / span).toFloat().coerceIn(0f, 1f)
         val highFrac = (((f.high ?: (weekMin + span)) - weekMin) / span).toFloat().coerceIn(0f, 1f)
@@ -174,7 +176,7 @@ class ClockWeatherCard : CardRenderer {
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(f.day, color = Color(0xFF9AB0C4), fontSize = 13.sp, modifier = Modifier.width(40.dp))
+            Text(f.day, color = theme.mutedText, fontSize = 13.sp, modifier = Modifier.width(40.dp))
             Text(
                 emojiFor(f.condition),
                 fontSize = 18.sp,
@@ -183,7 +185,7 @@ class ClockWeatherCard : CardRenderer {
             )
             Text(
                 f.low?.let { "${trim(it)}°" } ?: "",
-                color = Color(0xFF9AB0C4),
+                color = theme.mutedText,
                 fontSize = 13.sp,
                 textAlign = TextAlign.End,
                 modifier = Modifier.width(40.dp),
@@ -196,7 +198,7 @@ class ClockWeatherCard : CardRenderer {
                         .weight(1f)
                         .height(8.dp)
                         .clip(RoundedCornerShape(4.dp))
-                        .background(Color(0xFF2C3E4E)),
+                        .background(theme.controlBackground),
             ) {
                 Row(Modifier.matchParentSize()) {
                     Spacer(Modifier.weight(lowFrac.coerceAtLeast(0.001f)))
@@ -208,7 +210,7 @@ class ClockWeatherCard : CardRenderer {
                                 .clip(RoundedCornerShape(4.dp))
                                 .background(
                                     Brush.horizontalGradient(
-                                        listOf(Color(0xFF3DD68C), Color(0xFF9BE7C4)),
+                                        listOf(theme.success, theme.success),
                                     ),
                                 ),
                     )
@@ -218,7 +220,7 @@ class ClockWeatherCard : CardRenderer {
             Spacer(Modifier.width(8.dp))
             Text(
                 f.high?.let { "${trim(it)}°" } ?: "",
-                color = Color(0xFFF2F5FA),
+                color = theme.primaryText,
                 fontSize = 13.sp,
                 fontWeight = FontWeight.Medium,
                 textAlign = TextAlign.End,

--- a/app/src/main/java/com/custom/astrion/cards/impl/CoverCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/CoverCard.kt
@@ -47,6 +47,7 @@ import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.HaLabels
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.ThemeColors
 import com.custom.astrion.ui.icons.MdiIcons
 import kotlin.math.roundToInt
 
@@ -174,26 +175,29 @@ class CoverCard : CardRenderer {
                                 isOpen,
                                 isClosed,
                                 ::call,
+                                theme = ctx.theme,
                                 modifier = if (fillWidth) Modifier.fillMaxWidth() else Modifier,
                                 arrangement = if (fillWidth) Arrangement.SpaceEvenly else Arrangement.spacedBy(8.dp),
                             )
                             CoverControl.POSITION -> PercentSlider(
                                 entityId = "$entityId-position",
                                 value = position ?: 0,
-                                color = Color(0xFF6FA8DC),
+                                color = ctx.theme.accent,
+                                theme = ctx.theme,
                                 onCommit = ::setPosition,
                             )
                             CoverControl.TILT -> PercentSlider(
                                 entityId = "$entityId-tilt",
                                 value = tilt ?: 0,
-                                color = Color(0xFF8FBF7F),
+                                color = ctx.theme.success,
+                                theme = ctx.theme,
                                 onCommit = ::setTiltPosition,
                             )
                             null -> {}
                         }
                     }
                     if (controls.size > 1) {
-                        CycleControlButton {
+                        CycleControlButton(theme = ctx.theme) {
                             val idx = controls.indexOf(resolvedActive)
                             activeControl = controls[(idx + 1) % controls.size]
                         }
@@ -203,9 +207,9 @@ class CoverCard : CardRenderer {
         }
 
         when (config.string("layout")) {
-            "horizontal" -> HorizontalLayout(name, stateLabel, coverIcon, controlsSlot, modifier = tileGestureModifier)
-            "vertical" -> VerticalLayout(name, stateLabel, coverIcon, controlsSlot, modifier = tileGestureModifier)
-            else -> DefaultLayout(name, stateLabel, coverIcon, controlsSlot, modifier = tileGestureModifier)
+            "horizontal" -> HorizontalLayout(name, stateLabel, coverIcon, controlsSlot, ctx.theme, modifier = tileGestureModifier)
+            "vertical" -> VerticalLayout(name, stateLabel, coverIcon, controlsSlot, ctx.theme, modifier = tileGestureModifier)
+            else -> DefaultLayout(name, stateLabel, coverIcon, controlsSlot, ctx.theme, modifier = tileGestureModifier)
         }
 
         if (showDetail) {
@@ -214,6 +218,7 @@ class CoverCard : CardRenderer {
                 name = name,
                 e = e,
                 client = ctx.client,
+                theme = ctx.theme,
                 onClose = { showDetail = false },
             )
         }
@@ -225,15 +230,15 @@ private enum class CoverControl { BUTTONS, POSITION, TILT }
 // ---- shared pieces ---------------------------------------------------------
 
 @Composable
-private fun CoverIcon(icon: ImageVector, size: Dp = 42.dp) {
+private fun CoverIcon(icon: ImageVector, theme: ThemeColors, size: Dp = 42.dp) {
     Box(
         modifier = Modifier
             .size(size)
             .clip(RoundedCornerShape(12.dp))
-            .background(Color(0xFF2A4954)),
+            .background(theme.controlBackground),
         contentAlignment = Alignment.Center,
     ) {
-        Icon(icon, contentDescription = null, tint = Color(0xFFB6C9CE))
+        Icon(icon, contentDescription = null, tint = theme.iconTint)
     }
 }
 
@@ -241,19 +246,20 @@ private fun CoverIcon(icon: ImageVector, size: Dp = 42.dp) {
 private fun NameState(
     name: String,
     stateLabel: String,
+    theme: ThemeColors,
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     textAlign: TextAlign = TextAlign.Start,
 ) {
     Column(horizontalAlignment = horizontalAlignment) {
         Text(
             name,
-            color = Color(0xFFE6F0F1),
+            color = theme.primaryText,
             fontSize = 16.sp,
             fontWeight = FontWeight.SemiBold,
             maxLines = 1,
             textAlign = textAlign,
         )
-        Text(stateLabel, color = Color(0xFF93AFB6), fontSize = 13.sp, textAlign = textAlign)
+        Text(stateLabel, color = theme.mutedText, fontSize = 13.sp, textAlign = textAlign)
     }
 }
 
@@ -263,19 +269,21 @@ private fun ControlsRow(
     isOpen: Boolean,
     isClosed: Boolean,
     call: (String) -> Unit,
+    theme: ThemeColors,
     modifier: Modifier = Modifier,
     arrangement: Arrangement.Horizontal = Arrangement.spacedBy(8.dp),
 ) {
     Row(modifier = modifier, horizontalArrangement = arrangement) {
-        CircleBtn(MdiIcons.CoverUp, enabled = !isOpen) { call("open_cover") }
-        CircleBtn(Icons.Filled.Stop) { call("stop_cover") }
-        CircleBtn(MdiIcons.CoverDown, enabled = !isClosed) { call("close_cover") }
+        CircleBtn(MdiIcons.CoverUp, theme, enabled = !isOpen) { call("open_cover") }
+        CircleBtn(Icons.Filled.Stop, theme) { call("stop_cover") }
+        CircleBtn(MdiIcons.CoverDown, theme, enabled = !isClosed) { call("close_cover") }
     }
 }
 
 @Composable
 private fun CircleBtn(
     icon: ImageVector,
+    theme: ThemeColors,
     enabled: Boolean = true,
     onClick: () -> Unit,
 ) {
@@ -283,27 +291,27 @@ private fun CircleBtn(
         modifier = Modifier
             .size(44.dp)
             .clip(CircleShape)
-            .background(Color(0xFF2C4C58))
+            .background(theme.controlBackground)
             .alpha(if (enabled) 1f else 0.35f)
             .then(if (enabled) Modifier.clickable(onClick = onClick) else Modifier),
         contentAlignment = Alignment.Center,
     ) {
-        Icon(icon, contentDescription = null, tint = Color(0xFFCBDCE0))
+        Icon(icon, contentDescription = null, tint = theme.iconTint)
     }
 }
 
 /** Small round "next control" button — cycles through the enabled controls, Mushroom-style. */
 @Composable
-private fun CycleControlButton(onClick: () -> Unit) {
+private fun CycleControlButton(theme: ThemeColors, onClick: () -> Unit) {
     Box(
         modifier = Modifier
             .size(36.dp)
             .clip(CircleShape)
-            .background(Color(0xFF2C4C58))
+            .background(theme.controlBackground)
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
-        Icon(Icons.Filled.ChevronRight, contentDescription = null, tint = Color(0xFFCBDCE0))
+        Icon(Icons.Filled.ChevronRight, contentDescription = null, tint = theme.iconTint)
     }
 }
 
@@ -317,6 +325,7 @@ private fun PercentSlider(
     entityId: String,
     value: Int,
     color: Color,
+    theme: ThemeColors,
     onCommit: (Int) -> Unit,
 ) {
     // Uses -1f as a sentinel to denote 'no active drag', avoiding Float autoboxing.
@@ -329,7 +338,7 @@ private fun PercentSlider(
             .fillMaxWidth()
             .height(36.dp)
             .clip(RoundedCornerShape(18.dp))
-            .background(Color(0xFF152B33))
+            .background(theme.insetSurface)
             .pointerInput(entityId) {
                 detectHorizontalDragGestures(
                     onDragEnd = {
@@ -363,7 +372,7 @@ private fun PercentSlider(
         )
         Text(
             "${(shownFraction * 100).roundToInt()}%",
-            color = Color(0xFFE6F0F1),
+            color = theme.primaryText,
             fontSize = 13.sp,
             fontWeight = FontWeight.SemiBold,
         )
@@ -378,20 +387,21 @@ private fun DefaultLayout(
     stateLabel: String,
     icon: ImageVector,
     controls: @Composable (fillWidth: Boolean) -> Unit,
+    theme: ThemeColors,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(18.dp))
-            .background(Color(0xFF1E3841))
+            .background(theme.controlBackground)
             .padding(horizontal = 14.dp, vertical = 12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth().then(modifier)) {
-            CoverIcon(icon)
+            CoverIcon(icon, theme)
             Spacer(Modifier.width(12.dp))
-            NameState(name, stateLabel)
+            NameState(name, stateLabel, theme)
         }
         controls(true)
     }
@@ -405,19 +415,20 @@ private fun HorizontalLayout(
     stateLabel: String,
     icon: ImageVector,
     controls: @Composable (fillWidth: Boolean) -> Unit,
+    theme: ThemeColors,
     modifier: Modifier = Modifier,
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(18.dp))
-            .background(Color(0xFF1E3841))
+            .background(theme.controlBackground)
             .padding(horizontal = 14.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Box(Modifier.then(modifier)) { CoverIcon(icon) }
+        Box(Modifier.then(modifier)) { CoverIcon(icon, theme) }
         Spacer(Modifier.width(12.dp))
-        Box(Modifier.weight(1f).then(modifier)) { NameState(name, stateLabel) }
+        Box(Modifier.weight(1f).then(modifier)) { NameState(name, stateLabel, theme) }
         Box(Modifier.width(140.dp)) { controls(false) }
     }
 }
@@ -430,20 +441,21 @@ private fun VerticalLayout(
     stateLabel: String,
     icon: ImageVector,
     controls: @Composable (fillWidth: Boolean) -> Unit,
+    theme: ThemeColors,
     modifier: Modifier = Modifier,
 ) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(18.dp))
-            .background(Color(0xFF1E3841))
+            .background(theme.controlBackground)
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth().then(modifier)) {
-            CoverIcon(icon, size = 48.dp)
+            CoverIcon(icon, theme, size = 48.dp)
             Spacer(Modifier.height(8.dp))
-            NameState(name, stateLabel, horizontalAlignment = Alignment.CenterHorizontally, textAlign = TextAlign.Center)
+            NameState(name, stateLabel, theme, horizontalAlignment = Alignment.CenterHorizontally, textAlign = TextAlign.Center)
         }
         Spacer(Modifier.height(10.dp))
         controls(true)

--- a/app/src/main/java/com/custom/astrion/cards/impl/CoverDetailDialog.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/CoverDetailDialog.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.window.Dialog
 import com.custom.astrion.ha.EntityState
 import com.custom.astrion.ha.HaClient
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.ThemeColors
 import kotlin.math.roundToInt
 
 /**
@@ -43,6 +44,7 @@ fun CoverDetailDialog(
     name: String,
     e: EntityState?,
     client: HaClient,
+    theme: ThemeColors = ThemeColors.Default,
     onClose: () -> Unit,
 ) {
     val position = e?.attrInt("current_position") // 0..100
@@ -74,18 +76,18 @@ fun CoverDetailDialog(
             modifier =
                 Modifier
                     .clip(RoundedCornerShape(24.dp))
-                    .background(Color(0xFF1B343D))
+                    .background(theme.cardSurface)
                     .padding(20.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
             Text(
                 "${(dragLevel * 100).roundToInt()}%",
-                color = Color(0xFFE6F0F1),
+                color = theme.primaryText,
                 fontSize = 26.sp,
                 fontWeight = FontWeight.Bold,
             )
-            Text(name, color = Color(0xFF93AFB6), fontSize = 13.sp)
+            Text(name, color = theme.mutedText, fontSize = 13.sp)
 
             // Vertical position pill: drag or tap to set; fill rises from the bottom,
             // same interaction as LightDetailDialog's brightness pill.
@@ -95,7 +97,7 @@ fun CoverDetailDialog(
                         .width(120.dp)
                         .height(230.dp)
                         .clip(RoundedCornerShape(30.dp))
-                        .background(Color(0xFF152B33))
+                        .background(theme.insetSurface)
                         .pointerInput(entityId) {
                             detectVerticalDragGestures(
                                 onDragEnd = { commit(dragLevel) },
@@ -117,7 +119,7 @@ fun CoverDetailDialog(
                             .align(Alignment.BottomCenter)
                             .fillMaxWidth()
                             .fillMaxHeight(dragLevel.coerceIn(0.02f, 1f))
-                            .background(Color(0xFF6FA3B3).copy(alpha = 0.9f)),
+                            .background(theme.accent.copy(alpha = 0.9f)),
                 )
             }
 
@@ -132,11 +134,11 @@ fun CoverDetailDialog(
                         modifier =
                             Modifier
                                 .clip(RoundedCornerShape(12.dp))
-                                .background(Color(0xFF23414B))
+                                .background(theme.controlBackground)
                                 .clickable { setPreset(pct) }
                                 .padding(horizontal = 12.dp, vertical = 8.dp),
                     ) {
-                        Text("$pct%", color = Color(0xFFCBDCE0), fontSize = 12.sp)
+                        Text("$pct%", color = theme.iconTint, fontSize = 12.sp)
                     }
                 }
             }

--- a/app/src/main/java/com/custom/astrion/cards/impl/FanCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/FanCard.kt
@@ -27,6 +27,7 @@ import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.HaLabels
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.ThemeColors
 
 /**
  * Fan card. Two layouts, auto-picked from what the entity actually reports
@@ -117,7 +118,7 @@ class FanCard : CardRenderer {
                     Modifier
                         .fillMaxWidth()
                         .clip(RoundedCornerShape(18.dp))
-                        .background(if (on) Color(0xFF2B3A67) else Color(0xFF1E3841))
+                        .background(if (on) ctx.theme.controlBackground else ctx.theme.controlBackground)
                         .padding(horizontal = 16.dp, vertical = 12.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
@@ -127,16 +128,16 @@ class FanCard : CardRenderer {
                             .weight(1f)
                             .clickable { ctx.client.toggle(entityId) },
                 ) {
-                    Text(name, color = Color(0xFFE6F0F1), fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
+                    Text(name, color = ctx.theme.primaryText, fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
                     Text(
                         if (on) "$pct%" else stringResource(R.string.astrion_state_off),
-                        color = Color(0xFF93AFB6),
+                        color = ctx.theme.mutedText,
                         fontSize = 13.sp,
                     )
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    CircleBtn(Icons.Filled.KeyboardArrowDown) { setPercentage(pct - step) }
-                    CircleBtn(Icons.Filled.KeyboardArrowUp) { setPercentage(pct + step) }
+                    CircleBtn(Icons.Filled.KeyboardArrowDown, ctx.theme) { setPercentage(pct - step) }
+                    CircleBtn(Icons.Filled.KeyboardArrowUp, ctx.theme) { setPercentage(pct + step) }
                 }
             }
             return
@@ -147,7 +148,7 @@ class FanCard : CardRenderer {
                 Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(20.dp))
-                    .background(Color(0xFF1B343D))
+                    .background(ctx.theme.cardSurface)
                     .padding(14.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
@@ -157,20 +158,20 @@ class FanCard : CardRenderer {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(name, color = Color(0xFFE6F0F1), fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
+                Text(name, color = ctx.theme.primaryText, fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
                 Box(
                     modifier =
                         Modifier
                             .size(36.dp)
                             .clip(CircleShape)
-                            .background(if (on) Color(0xFF1E3A2E) else Color(0xFF3A2E2E))
+                            .background(if (on) ctx.theme.success.copy(alpha = 0.25f) else ctx.theme.danger.copy(alpha = 0.25f))
                             .clickable { ctx.client.toggle(entityId) },
                     contentAlignment = Alignment.Center,
                 ) {
                     Icon(
                         Icons.Filled.PowerSettingsNew,
                         contentDescription = "Power",
-                        tint = if (on) Color(0xFF9BE7C4) else Color(0xFFE06767),
+                        tint = if (on) ctx.theme.success else ctx.theme.danger,
                         modifier = Modifier.size(20.dp),
                     )
                 }
@@ -183,7 +184,7 @@ class FanCard : CardRenderer {
                     if (showCaptions) {
                         Text(
                             stringResource(R.string.fan_preset_caption),
-                            color = Color(0xFF6D8891),
+                            color = ctx.theme.mutedText,
                             fontSize = 11.sp,
                             fontWeight = FontWeight.Medium,
                         )
@@ -198,6 +199,7 @@ class FanCard : CardRenderer {
                                     FanChip(
                                         label = m,
                                         selected = on && presetMode?.equals(m, ignoreCase = true) == true,
+                                        theme = ctx.theme,
                                         modifier = Modifier.weight(1f),
                                     ) { setPreset(m) }
                                 }
@@ -211,14 +213,14 @@ class FanCard : CardRenderer {
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    CircleBtn(Icons.Filled.KeyboardArrowDown) { setPercentage(percentage - step) }
+                    CircleBtn(Icons.Filled.KeyboardArrowDown, ctx.theme) { setPercentage(percentage - step) }
                     Text(
                         "$percentage%",
-                        color = Color(0xFFE6F0F1),
+                        color = ctx.theme.primaryText,
                         fontSize = 20.sp,
                         fontWeight = FontWeight.SemiBold,
                     )
-                    CircleBtn(Icons.Filled.KeyboardArrowUp) { setPercentage(percentage + step) }
+                    CircleBtn(Icons.Filled.KeyboardArrowUp, ctx.theme) { setPercentage(percentage + step) }
                 }
             }
 
@@ -228,7 +230,7 @@ class FanCard : CardRenderer {
                     if (showCaptions) {
                         Text(
                             stringResource(R.string.fan_oscillate_caption),
-                            color = Color(0xFF6D8891),
+                            color = ctx.theme.mutedText,
                             fontSize = 11.sp,
                             fontWeight = FontWeight.Medium,
                         )
@@ -238,6 +240,7 @@ class FanCard : CardRenderer {
                         // same concept (oscillation on/off), no need for a second key.
                         label = HaLabels.swingMode(if (oscillating) "on" else "off"),
                         selected = oscillating,
+                        theme = ctx.theme,
                         modifier = Modifier.fillMaxWidth(),
                     ) { setOscillate(!oscillating) }
                 }
@@ -252,6 +255,7 @@ private fun FanChip(
     label: String,
     selected: Boolean,
     modifier: Modifier,
+    theme: ThemeColors,
     onClick: () -> Unit,
 ) {
     Box(
@@ -259,13 +263,13 @@ private fun FanChip(
             modifier
                 .height(34.dp)
                 .clip(RoundedCornerShape(10.dp))
-                .background(if (selected) Color(0xFF4C6EF5) else Color(0xFF23414B))
+                .background(if (selected) theme.accentSecondary else theme.controlBackground)
                 .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
         Text(
             label,
-            color = if (selected) Color.White else Color(0xFF93AFB6),
+            color = if (selected) Color.White else theme.mutedText,
             fontSize = 12.sp,
             fontWeight = FontWeight.Medium,
         )
@@ -292,6 +296,7 @@ private fun <T> balancedChunks(
 @Composable
 private fun CircleBtn(
     icon: ImageVector,
+    theme: ThemeColors,
     onClick: () -> Unit,
 ) {
     Box(
@@ -299,10 +304,10 @@ private fun CircleBtn(
             Modifier
                 .size(44.dp)
                 .clip(CircleShape)
-                .background(Color(0xFF2C4C58))
+                .background(theme.controlBackground)
                 .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
-        Icon(icon, contentDescription = null, tint = Color(0xFFCBDCE0))
+        Icon(icon, contentDescription = null, tint = theme.iconTint)
     }
 }

--- a/app/src/main/java/com/custom/astrion/cards/impl/LightCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/LightCard.kt
@@ -45,6 +45,7 @@ import com.custom.astrion.cards.CardConfig
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.ThemeColors
 import com.custom.astrion.ui.icons.MdiIcons
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
@@ -147,8 +148,8 @@ class LightCard : CardRenderer {
         val iconTint: Color
         when {
             !isOn -> {
-                iconBg = Color(0xFF2A4954)
-                iconTint = Color(0xFFB6C9CE)
+                iconBg = ctx.theme.controlBackground
+                iconTint = ctx.theme.iconTint
             }
             lightColor != null -> {
                 iconBg = lightColor.copy(alpha = 0.22f)
@@ -243,6 +244,7 @@ class LightCard : CardRenderer {
                                 entityId = "$entityId-brightness",
                                 value = brightnessPct ?: 0,
                                 color = barColor,
+                                theme = ctx.theme,
                                 onCommit = { pct -> commitBrightness(pct / 100f) },
                             )
                             LightControl.COLOR_TEMP -> ColorTempSlider(
@@ -257,7 +259,7 @@ class LightCard : CardRenderer {
                         }
                     }
                     if (controls.size > 1) {
-                        CycleControlButton {
+                        CycleControlButton(theme = ctx.theme) {
                             val idx = controls.indexOf(resolvedActive)
                             activeControl = controls[(idx + 1) % controls.size]
                         }
@@ -267,9 +269,9 @@ class LightCard : CardRenderer {
         }
 
         when (config.string("layout")) {
-            "horizontal" -> HorizontalLayout(name, stateLabel, icon, iconBg, iconTint, controlsSlot, modifier = tileGestureModifier)
-            "vertical" -> VerticalLayout(name, stateLabel, icon, iconBg, iconTint, controlsSlot, modifier = tileGestureModifier)
-            else -> DefaultLayout(name, stateLabel, icon, iconBg, iconTint, controlsSlot, modifier = tileGestureModifier)
+            "horizontal" -> HorizontalLayout(name, stateLabel, icon, iconBg, iconTint, controlsSlot, ctx.theme, modifier = tileGestureModifier)
+            "vertical" -> VerticalLayout(name, stateLabel, icon, iconBg, iconTint, controlsSlot, ctx.theme, modifier = tileGestureModifier)
+            else -> DefaultLayout(name, stateLabel, icon, iconBg, iconTint, controlsSlot, ctx.theme, modifier = tileGestureModifier)
         }
 
         if (showDetail) {
@@ -278,6 +280,7 @@ class LightCard : CardRenderer {
                 name = name,
                 e = e,
                 client = ctx.client,
+                theme = ctx.theme,
                 onClose = { showDetail = false },
             )
         }
@@ -311,34 +314,35 @@ private fun LightIcon(
 private fun NameState(
     name: String,
     stateLabel: String,
+    theme: ThemeColors,
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     textAlign: TextAlign = TextAlign.Start,
 ) {
     Column(horizontalAlignment = horizontalAlignment) {
         Text(
             name,
-            color = Color(0xFFE6F0F1),
+            color = theme.primaryText,
             fontSize = 16.sp,
             fontWeight = FontWeight.SemiBold,
             maxLines = 1,
             textAlign = textAlign,
         )
-        Text(stateLabel, color = Color(0xFF93AFB6), fontSize = 13.sp, textAlign = textAlign)
+        Text(stateLabel, color = theme.mutedText, fontSize = 13.sp, textAlign = textAlign)
     }
 }
 
 /** Small round "next control" button — cycles through the enabled controls, Mushroom-style. */
 @Composable
-private fun CycleControlButton(onClick: () -> Unit) {
+private fun CycleControlButton(theme: ThemeColors, onClick: () -> Unit) {
     Box(
         modifier = Modifier
             .size(36.dp)
             .clip(CircleShape)
-            .background(Color(0xFF2C4C58))
+            .background(theme.controlBackground)
             .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
-        Icon(Icons.Filled.ChevronRight, contentDescription = null, tint = Color(0xFFCBDCE0))
+        Icon(Icons.Filled.ChevronRight, contentDescription = null, tint = theme.iconTint)
     }
 }
 
@@ -353,6 +357,7 @@ private fun PercentSlider(
     entityId: String,
     value: Int,
     color: Color,
+    theme: ThemeColors,
     onCommit: (Int) -> Unit,
 ) {
     // Uses -1f as a sentinel to denote 'no active drag', avoiding Float autoboxing.
@@ -366,7 +371,7 @@ private fun PercentSlider(
                 .fillMaxWidth()
                 .height(36.dp)
                 .clip(RoundedCornerShape(18.dp))
-                .background(Color(0xFF152B33))
+                .background(theme.insetSurface)
                 .pointerInput(entityId) {
                     detectHorizontalDragGestures(
                         onDragEnd = {
@@ -401,7 +406,7 @@ private fun PercentSlider(
         )
         Text(
             "${(shownFraction * 100).roundToInt()}%",
-            color = Color(0xFFE6F0F1),
+            color = theme.primaryText,
             fontSize = 13.sp,
             fontWeight = FontWeight.SemiBold,
         )
@@ -500,6 +505,7 @@ private fun DefaultLayout(
     iconBg: Color,
     iconTint: Color,
     controls: @Composable (fillWidth: Boolean) -> Unit,
+    theme: ThemeColors,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -507,14 +513,14 @@ private fun DefaultLayout(
             Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(18.dp))
-                .background(Color(0xFF1E3841))
+                .background(theme.controlBackground)
                 .padding(horizontal = 14.dp, vertical = 12.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth().then(modifier)) {
             LightIcon(icon, iconBg, iconTint)
             Spacer(Modifier.width(12.dp))
-            NameState(name, stateLabel)
+            NameState(name, stateLabel, theme)
         }
         // Controls live outside modifier's tap/long-press area so dragging
         // them doesn't also toggle the light or open the dialog.
@@ -532,6 +538,7 @@ private fun HorizontalLayout(
     iconBg: Color,
     iconTint: Color,
     controls: @Composable (fillWidth: Boolean) -> Unit,
+    theme: ThemeColors,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -539,13 +546,13 @@ private fun HorizontalLayout(
             Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(18.dp))
-                .background(Color(0xFF1E3841))
+                .background(theme.controlBackground)
                 .padding(horizontal = 14.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(Modifier.then(modifier)) { LightIcon(icon, iconBg, iconTint) }
         Spacer(Modifier.width(12.dp))
-        Box(Modifier.weight(1f).then(modifier)) { NameState(name, stateLabel) }
+        Box(Modifier.weight(1f).then(modifier)) { NameState(name, stateLabel, theme) }
         Box(Modifier.width(140.dp)) { controls(false) }
     }
 }
@@ -560,6 +567,7 @@ private fun VerticalLayout(
     iconBg: Color,
     iconTint: Color,
     controls: @Composable (fillWidth: Boolean) -> Unit,
+    theme: ThemeColors,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -567,7 +575,7 @@ private fun VerticalLayout(
             Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(18.dp))
-                .background(Color(0xFF1E3841))
+                .background(theme.controlBackground)
                 .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
@@ -577,7 +585,7 @@ private fun VerticalLayout(
         ) {
             LightIcon(icon, iconBg, iconTint, size = 48.dp)
             Spacer(Modifier.height(8.dp))
-            NameState(name, stateLabel, horizontalAlignment = Alignment.CenterHorizontally, textAlign = TextAlign.Center)
+            NameState(name, stateLabel, theme, horizontalAlignment = Alignment.CenterHorizontally, textAlign = TextAlign.Center)
         }
         Spacer(Modifier.height(10.dp))
         controls(true)

--- a/app/src/main/java/com/custom/astrion/cards/impl/LightDetailDialog.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/LightDetailDialog.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.window.Dialog
 import com.custom.astrion.ha.EntityState
 import com.custom.astrion.ha.HaClient
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.ThemeColors
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.math.roundToInt
@@ -45,6 +46,7 @@ fun LightDetailDialog(
     name: String,
     e: EntityState?,
     client: HaClient,
+    theme: ThemeColors = ThemeColors.Default,
     onClose: () -> Unit,
 ) {
     val on = e?.isOn == true
@@ -69,7 +71,7 @@ fun LightDetailDialog(
             fun ch(i: Int) = (rgb[i] as? JsonPrimitive)?.content?.toIntOrNull()?.coerceIn(0, 255) ?: 255
             Color(ch(0), ch(1), ch(2))
         } else {
-            Color(0xFFFFD9A0)
+            theme.amber
         }
 
     fun commit(fraction: Float) {
@@ -105,18 +107,18 @@ fun LightDetailDialog(
             modifier =
                 Modifier
                     .clip(RoundedCornerShape(24.dp))
-                    .background(Color(0xFF1B343D))
+                    .background(theme.cardSurface)
                     .padding(20.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
             Text(
                 "${(dragLevel * 100).roundToInt()}%",
-                color = Color(0xFFE6F0F1),
+                color = theme.primaryText,
                 fontSize = 26.sp,
                 fontWeight = FontWeight.Bold,
             )
-            Text(name, color = Color(0xFF93AFB6), fontSize = 13.sp)
+            Text(name, color = theme.mutedText, fontSize = 13.sp)
 
             // Vertical brightness pill: drag or tap to set; fill rises from the bottom.
             Box(
@@ -125,7 +127,7 @@ fun LightDetailDialog(
                         .width(120.dp)
                         .height(230.dp)
                         .clip(RoundedCornerShape(30.dp))
-                        .background(Color(0xFF152B33))
+                        .background(theme.insetSurface)
                         .pointerInput(entityId) {
                             detectVerticalDragGestures(
                                 onDragEnd = { commit(dragLevel) },
@@ -157,14 +159,14 @@ fun LightDetailDialog(
                     Modifier
                         .size(48.dp)
                         .clip(CircleShape)
-                        .background(if (on) Color(0xFFFFC24B) else Color(0xFF2C4C58))
+                        .background(if (on) theme.amber else theme.controlBackground)
                         .clickable { client.toggle(entityId) },
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
                     Icons.Filled.PowerSettingsNew,
                     contentDescription = "Toggle",
-                    tint = if (on) Color(0xFF241A00) else Color(0xFFCBDCE0),
+                    tint = if (on) Color(0xFF241A00) else theme.iconTint,
                 )
             }
 
@@ -201,11 +203,11 @@ fun LightDetailDialog(
                             modifier =
                                 Modifier
                                     .clip(RoundedCornerShape(12.dp))
-                                    .background(Color(0xFF23414B))
+                                    .background(theme.controlBackground)
                                     .clickable { setKelvin(k) }
                                     .padding(horizontal = 12.dp, vertical = 8.dp),
                         ) {
-                            Text(label, color = Color(0xFFCBDCE0), fontSize = 12.sp)
+                            Text(label, color = theme.iconTint, fontSize = 12.sp)
                         }
                     }
                 }

--- a/app/src/main/java/com/custom/astrion/cards/impl/MediaBrowser.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/MediaBrowser.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import com.custom.astrion.ha.HaClient
+import com.custom.astrion.ui.ThemeColors
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -53,6 +54,7 @@ private data class MediaItem(
 fun MediaBrowser(
     entityId: String,
     client: HaClient,
+    theme: ThemeColors = ThemeColors.Default,
     onClose: () -> Unit,
 ) {
     // Navigation stack of (contentId, contentType); root is (null, null).
@@ -83,45 +85,45 @@ fun MediaBrowser(
                     .fillMaxWidth()
                     .fillMaxHeight(0.85f)
                     .clip(RoundedCornerShape(18.dp))
-                    .background(Color(0xFF1B343D))
+                    .background(theme.cardSurface)
                     .padding(12.dp),
         ) {
             // Header: back (when nested), title, close.
             Row(verticalAlignment = Alignment.CenterVertically) {
                 if (stack.size > 1) {
-                    IconBtn(Icons.Filled.ArrowBack) { if (stack.size > 1) stack.removeAt(stack.size - 1) }
+                    IconBtn(Icons.Filled.ArrowBack, theme) { if (stack.size > 1) stack.removeAt(stack.size - 1) }
                     Spacer(Modifier.width(6.dp))
                 }
                 Text(
                     title,
-                    color = Color(0xFFE6F0F1),
+                    color = theme.primaryText,
                     fontSize = 17.sp,
                     fontWeight = FontWeight.SemiBold,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.weight(1f),
                 )
-                IconBtn(Icons.Filled.Close, onClick = onClose)
+                IconBtn(Icons.Filled.Close, theme, onClick = onClose)
             }
             Spacer(Modifier.height(8.dp))
 
             when {
                 items == null ->
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        CircularProgressIndicator(color = Color(0xFF6EA8FE))
+                        CircularProgressIndicator(color = theme.accent)
                     }
                 error != null ->
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        Text(error!!, color = Color(0xFFE0A0A0), fontSize = 14.sp)
+                        Text(error!!, color = theme.danger, fontSize = 14.sp)
                     }
                 items!!.isEmpty() ->
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        Text("Nothing here", color = Color(0xFF93AFB6), fontSize = 14.sp)
+                        Text("Nothing here", color = theme.mutedText, fontSize = 14.sp)
                     }
                 else ->
                     LazyColumn(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                         items(items!!) { item ->
-                            MediaRow(item) {
+                            MediaRow(item, theme) {
                                 when {
                                     item.canExpand -> stack.add(item.contentId to item.contentType)
                                     item.canPlay -> {
@@ -140,6 +142,7 @@ fun MediaBrowser(
 @Composable
 private fun MediaRow(
     item: MediaItem,
+    theme: ThemeColors,
     onClick: () -> Unit,
 ) {
     Row(
@@ -153,16 +156,16 @@ private fun MediaRow(
     ) {
         Text(
             item.title,
-            color = Color(0xFFE6F0F1),
+            color = theme.primaryText,
             fontSize = 15.sp,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.weight(1f),
         )
         if (item.canExpand) {
-            Icon(Icons.Filled.ChevronRight, contentDescription = null, tint = Color(0xFF93AFB6))
+            Icon(Icons.Filled.ChevronRight, contentDescription = null, tint = theme.mutedText)
         } else if (item.canPlay) {
-            Icon(Icons.Filled.PlayArrow, contentDescription = null, tint = Color(0xFF6EA8FE))
+            Icon(Icons.Filled.PlayArrow, contentDescription = null, tint = theme.accent)
         }
     }
 }
@@ -170,6 +173,7 @@ private fun MediaRow(
 @Composable
 private fun IconBtn(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
+    theme: ThemeColors,
     onClick: () -> Unit,
 ) {
     Box(
@@ -179,7 +183,7 @@ private fun IconBtn(
                 .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
-        Icon(icon, contentDescription = null, tint = Color(0xFFCBDCE0))
+        Icon(icon, contentDescription = null, tint = theme.iconTint)
     }
 }
 

--- a/app/src/main/java/com/custom/astrion/cards/impl/MediaPlayerCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/MediaPlayerCard.kt
@@ -41,6 +41,7 @@ import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.EntityState
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.ThemeColors
 import com.custom.astrion.ui.icons.MdiIcons
 import kotlin.time.Duration.Companion.seconds
 
@@ -150,11 +151,11 @@ class MediaPlayerCard : CardRenderer {
                     Modifier
                         .fillMaxWidth()
                         .clip(RoundedCornerShape(20.dp))
-                        .background(Color(0xFF1B343D)),
+                        .background(ctx.theme.cardSurface),
             ) {
                 blurredBg?.let { bg ->
                     Image(bg, null, modifier = Modifier.matchParentSize(), contentScale = ContentScale.Crop)
-                    Box(modifier = Modifier.matchParentSize().background(Color(0xB30D1E24)))
+                    Box(modifier = Modifier.matchParentSize().background(ctx.theme.background.copy(alpha = 0.7f)))
                 }
                 FullContent(ctx, e, entityId, title, subtitle ?: stateLabel, art, ::mp, topButtons, mediaControls, volumeControls)
             }
@@ -168,6 +169,7 @@ class MediaPlayerCard : CardRenderer {
                 art = art,
                 mediaControls = mediaControls,
                 volumeControls = volumeControls,
+                theme = ctx.theme,
                 onTap = { mp("media_play_pause") },
                 onLongPress = { showDetail = true },
                 mp = ::mp,
@@ -178,6 +180,7 @@ class MediaPlayerCard : CardRenderer {
                     name = title,
                     e = e,
                     client = ctx.client,
+                    theme = ctx.theme,
                     onClose = { showDetail = false },
                 )
             }
@@ -210,6 +213,7 @@ class MediaPlayerCard : CardRenderer {
         art: ImageBitmap?,
         mediaControls: List<String>,
         volumeControls: List<String>,
+        theme: ThemeColors,
         onTap: () -> Unit,
         onLongPress: () -> Unit,
         mp: (String, Array<out Pair<String, Any?>>) -> Unit,
@@ -235,7 +239,7 @@ class MediaPlayerCard : CardRenderer {
                 Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(18.dp))
-                    .background(Color(0xFF1E3841))
+                    .background(theme.controlBackground)
                     .padding(horizontal = 14.dp, vertical = 12.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
@@ -249,13 +253,13 @@ class MediaPlayerCard : CardRenderer {
                 } else {
                     val isOff = e == null || e.state == "off" || e.isUnavailable
                     Box(
-                        avatarMod.background(if (isOff) Color(0xFF2A4954) else Color(0xFF4C6EF5)),
+                        avatarMod.background(if (isOff) theme.controlBackground else theme.accentSecondary),
                         contentAlignment = Alignment.Center
                     ) {
                         Icon(
                             if (isOff) MdiIcons.CastOff else MdiIcons.Cast,
                             contentDescription = null,
-                            tint = if (isOff) Color(0xFFB6C9CE) else Color.White,
+                            tint = if (isOff) theme.iconTint else Color.White,
                             modifier = Modifier.size(20.dp),
                         )
                     }
@@ -264,7 +268,7 @@ class MediaPlayerCard : CardRenderer {
                 Column(Modifier.weight(1f)) {
                     Text(
                         title,
-                        color = Color(0xFFE6F0F1),
+                        color = theme.primaryText,
                         fontSize = 16.sp,
                         fontWeight = FontWeight.SemiBold,
                         maxLines = 1,
@@ -272,7 +276,7 @@ class MediaPlayerCard : CardRenderer {
                     )
                     Text(
                         state,
-                        color = Color(0xFF93AFB6),
+                        color = theme.mutedText,
                         fontSize = 13.sp,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
@@ -288,14 +292,14 @@ class MediaPlayerCard : CardRenderer {
                 ) {
                     if (activeIsVolume) {
                         if (hasVolumeSlider) {
-                            VolumeSlider(entityId, e, Modifier.weight(1f)) { level ->
+                            VolumeSlider(entityId, e, Modifier.weight(1f), theme) { level ->
                                 mp("volume_set", arrayOf("volume_level" to level))
                             }
                         }
-                        volumeButtons.forEach { b -> TileButton(b.icon) { mp(b.action, b.data.toTypedArray()) } }
+                        volumeButtons.forEach { b -> TileButton(b.icon, theme = theme) { mp(b.action, b.data.toTypedArray()) } }
                     } else {
                         mediaButtons.forEach { b ->
-                            TileButton(b.icon, accent = b.active || b.action == "media_play" || b.action == "media_pause") {
+                            TileButton(b.icon, theme = theme, accent = b.active || b.action == "media_play" || b.action == "media_pause") {
                                 mp(b.action, b.data.toTypedArray())
                             }
                         }
@@ -309,7 +313,7 @@ class MediaPlayerCard : CardRenderer {
                         if (!(activeIsVolume && hasVolumeSlider)) {
                             Spacer(Modifier.weight(1f))
                         }
-                        TileButton(if (activeIsVolume) MdiIcons.Play else MdiIcons.VolumeHigh) {
+                        TileButton(if (activeIsVolume) MdiIcons.Play else MdiIcons.VolumeHigh, theme = theme) {
                             showVolume = !showVolume
                         }
                     }
@@ -321,6 +325,7 @@ class MediaPlayerCard : CardRenderer {
     @Composable
     private fun TileButton(
         icon: ImageVector,
+        theme: ThemeColors,
         accent: Boolean = false,
         onClick: () -> Unit,
     ) {
@@ -329,11 +334,11 @@ class MediaPlayerCard : CardRenderer {
                 Modifier
                     .size(36.dp)
                     .clip(RoundedCornerShape(10.dp))
-                    .background(if (accent) Color(0xFF4C6EF5) else Color(0xFF23414B))
+                    .background(if (accent) theme.accentSecondary else theme.controlBackground)
                     .clickable(onClick = onClick),
             contentAlignment = Alignment.Center,
         ) {
-            Icon(icon, contentDescription = null, tint = Color(0xFFE6F0F1), modifier = Modifier.size(18.dp))
+            Icon(icon, contentDescription = null, tint = theme.primaryText, modifier = Modifier.size(18.dp))
         }
     }
 
@@ -342,6 +347,7 @@ class MediaPlayerCard : CardRenderer {
         entityId: String,
         e: EntityState?,
         modifier: Modifier,
+        theme: ThemeColors,
         onCommit: (Float) -> Unit,
     ) {
         val level = (e?.attrDouble("volume_level") ?: 0.0).toFloat().coerceIn(0f, 1f)
@@ -352,7 +358,7 @@ class MediaPlayerCard : CardRenderer {
                 modifier
                     .height(36.dp)
                     .clip(RoundedCornerShape(10.dp))
-                    .background(Color(0xFF152B33))
+                    .background(theme.insetSurface)
                     .pointerInput(entityId) {
                         detectHorizontalDragGestures(
                             onDragEnd = { dragLevel?.let(onCommit); dragLevel = null },
@@ -376,7 +382,7 @@ class MediaPlayerCard : CardRenderer {
                     .fillMaxHeight()
                     .fillMaxWidth(shown.coerceIn(0.02f, 1f))
                     .clip(RoundedCornerShape(10.dp))
-                    .background(Color(0xFF4C6EF5)),
+                    .background(theme.accentSecondary),
             )
         }
     }
@@ -414,11 +420,11 @@ class MediaPlayerCard : CardRenderer {
                                     .weight(1f)
                                     .height(44.dp)
                                     .clip(RoundedCornerShape(12.dp))
-                                    .background(Color(0x662C4C58))
+                                    .background(ctx.theme.controlBackground.copy(alpha = 0.4f))
                                     .clickable { fireService(ctx, b) },
                             contentAlignment = Alignment.Center,
                         ) {
-                            Text(b["name"] as? String ?: "", color = Color(0xFFE6F0F1), fontSize = 15.sp, fontWeight = FontWeight.Medium)
+                            Text(b["name"] as? String ?: "", color = ctx.theme.primaryText, fontSize = 15.sp, fontWeight = FontWeight.Medium)
                         }
                     }
                 }
@@ -430,13 +436,13 @@ class MediaPlayerCard : CardRenderer {
             } else {
                 val isOff = e == null || e.state == "off" || e.isUnavailable
                 Box(
-                    artMod.background(if (isOff) Color(0xFF3A2E5A) else Color(0xFF4C6EF5)),
+                    artMod.background(if (isOff) ctx.theme.controlBackground else ctx.theme.accentSecondary),
                     contentAlignment = Alignment.Center
                 ) {
                     Icon(
                         if (isOff) MdiIcons.CastOff else MdiIcons.Cast,
                         contentDescription = null,
-                        tint = if (isOff) Color(0x99FFFFFF) else Color.White,
+                        tint = if (isOff) Color.White.copy(alpha = 0.6f) else Color.White,
                         modifier = Modifier.size(48.dp),
                     )
                 }
@@ -445,7 +451,7 @@ class MediaPlayerCard : CardRenderer {
             Column(modifier = Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(
                     title,
-                    color = Color(0xFFF1F4FA),
+                    color = ctx.theme.primaryText,
                     fontSize = 20.sp,
                     fontWeight = FontWeight.Bold,
                     maxLines = 2,
@@ -455,7 +461,7 @@ class MediaPlayerCard : CardRenderer {
                 )
                 Text(
                     artist,
-                    color = Color(0xFFB6BECC),
+                    color = ctx.theme.mutedText,
                     fontSize = 14.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
@@ -465,7 +471,7 @@ class MediaPlayerCard : CardRenderer {
             }
 
             if (e?.attrDouble("media_duration") != null) {
-                MediaProgressBar(e)
+                MediaProgressBar(e, ctx.theme)
             }
 
             if (mediaButtons.isNotEmpty()) {
@@ -476,7 +482,7 @@ class MediaPlayerCard : CardRenderer {
                 ) {
                     mediaButtons.forEach { b ->
                         val big = b.action == "media_play" || b.action == "media_pause"
-                        FullCircleControl(b.icon, if (big) 64.dp else 50.dp, accent = big || b.active) {
+                        FullCircleControl(b.icon, if (big) 64.dp else 50.dp, ctx.theme, accent = big || b.active) {
                             mp(b.action, b.data.toTypedArray())
                         }
                     }
@@ -490,18 +496,18 @@ class MediaPlayerCard : CardRenderer {
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     if (hasVolumeSlider) {
-                        VolumeSlider(entityId, e, Modifier.weight(1f).height(44.dp)) { level ->
+                        VolumeSlider(entityId, e, Modifier.weight(1f).height(44.dp), ctx.theme) { level ->
                             mp("volume_set", arrayOf("volume_level" to level))
                         }
                     }
-                    volumeButtons.forEach { b -> FullCircleControl(b.icon, 44.dp) { mp(b.action, b.data.toTypedArray()) } }
+                    volumeButtons.forEach { b -> FullCircleControl(b.icon, 44.dp, ctx.theme) { mp(b.action, b.data.toTypedArray()) } }
                 }
             }
         }
     }
 
     @Composable
-    private fun MediaProgressBar(e: EntityState) {
+    private fun MediaProgressBar(e: EntityState, theme: ThemeColors) {
         val duration = e.attrDouble("media_duration") ?: 0.0
         // Keyed on the raw JsonElement's string form, not attrString() —
         // Kodi reports media_content_id as a nested JsonObject
@@ -527,19 +533,19 @@ class MediaPlayerCard : CardRenderer {
                         .fillMaxWidth()
                         .height(4.dp)
                         .clip(RoundedCornerShape(2.dp))
-                        .background(Color(0x33FFFFFF)),
+                        .background(Color.White.copy(alpha = 0.2f)),
             ) {
                 Box(
                     Modifier
                         .fillMaxHeight()
                         .fillMaxWidth(fraction.coerceAtLeast(0.01f))
                         .clip(RoundedCornerShape(2.dp))
-                        .background(Color(0xFF4C6EF5)),
+                        .background(theme.accentSecondary),
                 )
             }
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-                Text(formatMediaTime(elapsed), color = Color(0xFF93AFB6), fontSize = 11.sp)
-                Text(formatMediaTime(duration), color = Color(0xFF93AFB6), fontSize = 11.sp)
+                Text(formatMediaTime(elapsed), color = theme.mutedText, fontSize = 11.sp)
+                Text(formatMediaTime(duration), color = theme.mutedText, fontSize = 11.sp)
             }
         }
     }
@@ -548,6 +554,7 @@ class MediaPlayerCard : CardRenderer {
     private fun FullCircleControl(
         icon: ImageVector,
         size: Dp,
+        theme: ThemeColors,
         accent: Boolean = false,
         onClick: () -> Unit,
     ) {
@@ -556,7 +563,7 @@ class MediaPlayerCard : CardRenderer {
                 Modifier
                     .size(size)
                     .clip(CircleShape)
-                    .background(if (accent) Color(0xFF4C6EF5) else Color(0x552C4C58))
+                    .background(if (accent) theme.accentSecondary else theme.controlBackground.copy(alpha = 0.33f))
                     .clickable(onClick = onClick),
             contentAlignment = Alignment.Center,
         ) {

--- a/app/src/main/java/com/custom/astrion/cards/impl/MediaPlayerDetailDialog.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/MediaPlayerDetailDialog.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.window.Dialog
 import com.custom.astrion.ha.EntityState
 import com.custom.astrion.ha.HaClient
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.ThemeColors
 import com.custom.astrion.ui.icons.MdiIcons
 import kotlin.time.Duration.Companion.seconds
 
@@ -54,6 +55,7 @@ fun MediaPlayerDetailDialog(
     name: String,
     e: EntityState?,
     client: HaClient,
+    theme: ThemeColors = ThemeColors.Default,
     onClose: () -> Unit,
 ) {
     val mediaButtons = remember(e) { computeMediaButtons(e, MediaPlayerCard.MEDIA_CONTROL_KEYS) }
@@ -83,7 +85,7 @@ fun MediaPlayerDetailDialog(
             modifier =
                 Modifier
                     .clip(RoundedCornerShape(24.dp))
-                    .background(Color(0xFF1B343D))
+                    .background(theme.cardSurface)
                     .padding(20.dp)
                     .width(300.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -94,11 +96,11 @@ fun MediaPlayerDetailDialog(
                 Image(art!!, null, modifier = artMod, contentScale = ContentScale.Crop)
             } else {
                 val isOff = e == null || e.state == "off" || e.isUnavailable
-                Box(artMod.background(Color(0xFF3A2E5A)), contentAlignment = Alignment.Center) {
+                Box(artMod.background(theme.controlBackground), contentAlignment = Alignment.Center) {
                     Icon(
                         if (isOff) MdiIcons.CastOff else MdiIcons.Cast,
                         contentDescription = null,
-                        tint = Color(0x99FFFFFF),
+                        tint = Color.White.copy(alpha = 0.6f),
                         modifier = Modifier.size(48.dp),
                     )
                 }
@@ -107,7 +109,7 @@ fun MediaPlayerDetailDialog(
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(
                     title,
-                    color = Color(0xFFE6F0F1),
+                    color = theme.primaryText,
                     fontSize = 18.sp,
                     fontWeight = FontWeight.Bold,
                     maxLines = 2,
@@ -116,7 +118,7 @@ fun MediaPlayerDetailDialog(
                 )
                 Text(
                     subtitle ?: mediaStateLabel(e?.state),
-                    color = Color(0xFF93AFB6),
+                    color = theme.mutedText,
                     fontSize = 13.sp,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
@@ -125,7 +127,7 @@ fun MediaPlayerDetailDialog(
             }
 
             if (e != null && e.attrDouble("media_duration") != null) {
-                DialogProgressBar(e)
+                DialogProgressBar(e, theme)
             }
 
             if (mediaButtons.isNotEmpty()) {
@@ -136,7 +138,7 @@ fun MediaPlayerDetailDialog(
                 ) {
                     mediaButtons.forEach { b ->
                         val big = b.action == "media_play" || b.action == "media_pause"
-                        Circle(b.icon, if (big) 60.dp else 46.dp, accent = big || b.active) {
+                        Circle(b.icon, if (big) 60.dp else 46.dp, theme, accent = big || b.active) {
                             mp(b.action, b.data.toTypedArray())
                         }
                     }
@@ -149,14 +151,14 @@ fun MediaPlayerDetailDialog(
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    volumeButtons.forEach { b -> Circle(b.icon, 40.dp) { mp(b.action, b.data.toTypedArray()) } }
+                    volumeButtons.forEach { b -> Circle(b.icon, 40.dp, theme) { mp(b.action, b.data.toTypedArray()) } }
                     if (hasVolumeSet) {
-                        DialogVolumeSlider(entityId, e, Modifier.weight(1f)) { level ->
+                        DialogVolumeSlider(entityId, e, Modifier.weight(1f), theme) { level ->
                             mp("volume_set", arrayOf("volume_level" to level))
                         }
                     } else if (hasVolumeStep) {
-                        Circle(MdiIcons.VolumeOff, 40.dp) { mp("volume_down") }
-                        Circle(MdiIcons.VolumeHigh, 40.dp) { mp("volume_up") }
+                        Circle(MdiIcons.VolumeOff, 40.dp, theme) { mp("volume_down") }
+                        Circle(MdiIcons.VolumeHigh, 40.dp, theme) { mp("volume_up") }
                     }
                 }
             }
@@ -170,7 +172,7 @@ fun MediaPlayerDetailDialog(
                         Modifier
                             .size(44.dp)
                             .clip(CircleShape)
-                            .background(if (on) Color(0xFF4C6EF5) else Color(0xFF2C4C58))
+                            .background(if (on) theme.accentSecondary else theme.controlBackground)
                             .clickable { mp(if (on) "turn_off" else "turn_on") },
                     contentAlignment = Alignment.Center,
                 ) {
@@ -182,7 +184,7 @@ fun MediaPlayerDetailDialog(
 }
 
 @Composable
-private fun DialogProgressBar(e: EntityState) {
+private fun DialogProgressBar(e: EntityState, theme: ThemeColors) {
     val duration = e.attrDouble("media_duration") ?: 0.0
     // See MediaPlayerCard.MediaProgressBar's identical comment — Kodi's
     // media_content_id is a nested JsonObject, not a plain string, so this
@@ -205,19 +207,19 @@ private fun DialogProgressBar(e: EntityState) {
                     .fillMaxWidth()
                     .height(4.dp)
                     .clip(RoundedCornerShape(2.dp))
-                    .background(Color(0xFF152B33)),
+                    .background(theme.insetSurface),
         ) {
             Box(
                 Modifier
                     .fillMaxHeight()
                     .fillMaxWidth(fraction.coerceAtLeast(0.01f))
                     .clip(RoundedCornerShape(2.dp))
-                    .background(Color(0xFF4C6EF5)),
+                    .background(theme.accentSecondary),
             )
         }
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-            Text(formatMediaTime(elapsed), color = Color(0xFF93AFB6), fontSize = 11.sp)
-            Text(formatMediaTime(duration), color = Color(0xFF93AFB6), fontSize = 11.sp)
+            Text(formatMediaTime(elapsed), color = theme.mutedText, fontSize = 11.sp)
+            Text(formatMediaTime(duration), color = theme.mutedText, fontSize = 11.sp)
         }
     }
 }
@@ -227,6 +229,7 @@ private fun DialogVolumeSlider(
     entityId: String,
     e: EntityState?,
     modifier: Modifier,
+    theme: ThemeColors,
     onCommit: (Float) -> Unit,
 ) {
     val level = (e?.attrDouble("volume_level") ?: 0.0).toFloat().coerceIn(0f, 1f)
@@ -237,7 +240,7 @@ private fun DialogVolumeSlider(
             modifier
                 .height(40.dp)
                 .clip(RoundedCornerShape(12.dp))
-                .background(Color(0xFF152B33))
+                .background(theme.insetSurface)
                 .pointerInput(entityId) {
                     detectHorizontalDragGestures(
                         onDragEnd = { dragLevel?.let(onCommit); dragLevel = null },
@@ -258,7 +261,7 @@ private fun DialogVolumeSlider(
                 .fillMaxHeight()
                 .fillMaxWidth(shown.coerceIn(0.02f, 1f))
                 .clip(RoundedCornerShape(12.dp))
-                .background(Color(0xFF4C6EF5)),
+                .background(theme.accentSecondary),
         )
     }
 }
@@ -267,6 +270,7 @@ private fun DialogVolumeSlider(
 private fun Circle(
     icon: ImageVector,
     size: androidx.compose.ui.unit.Dp,
+    theme: ThemeColors,
     accent: Boolean = false,
     onClick: () -> Unit,
 ) {
@@ -275,7 +279,7 @@ private fun Circle(
             Modifier
                 .size(size)
                 .clip(CircleShape)
-                .background(if (accent) Color(0xFF4C6EF5) else Color(0xFF23414B))
+                .background(if (accent) theme.accentSecondary else theme.controlBackground)
                 .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {

--- a/app/src/main/java/com/custom/astrion/cards/impl/MonitorCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/MonitorCard.kt
@@ -50,14 +50,14 @@ class MonitorCard : CardRenderer {
                 Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(18.dp))
-                    .background(Color(0xFF1B343D))
+                    .background(ctx.theme.cardSurface)
                     .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             if (!title.isNullOrBlank()) {
                 Text(
                     title,
-                    color = Color(0xFFE6F0F1),
+                    color = ctx.theme.primaryText,
                     fontSize = 16.sp,
                     fontWeight = FontWeight.SemiBold,
                 )
@@ -73,10 +73,10 @@ class MonitorCard : CardRenderer {
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Text(name, color = Color(0xFF93AFB6), fontSize = 14.sp, modifier = Modifier.weight(1f))
+                    Text(name, color = ctx.theme.mutedText, fontSize = 14.sp, modifier = Modifier.weight(1f))
                     Text(
                         if (unit.isBlank()) value else "$value $unit",
-                        color = Color(0xFFE6F0F1),
+                        color = ctx.theme.primaryText,
                         fontSize = 16.sp,
                         fontWeight = FontWeight.Medium,
                     )

--- a/app/src/main/java/com/custom/astrion/cards/impl/PictureElementsCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/PictureElementsCard.kt
@@ -100,7 +100,7 @@ class PictureElementsCard : CardRenderer {
                     .fillMaxWidth()
                     .aspectRatio(aspect)
                     .clip(RoundedCornerShape(18.dp))
-                    .background(Color(0xFF0E1116)),
+                    .background(ctx.theme.background),
         ) {
             if (bitmap != null) {
                 Image(
@@ -128,7 +128,7 @@ class PictureElementsCard : CardRenderer {
                 val x = w * (leftPct / 100f) - iconBox / 2
                 val y = h * (topPct / 100f) - iconBox / 2
 
-                val bg = if (on) Color(0x66FFC24B) else Color(0x33000000)
+                val bg = if (on) ctx.theme.amber.copy(alpha = 0.4f) else Color.Black.copy(alpha = 0.2f)
                 val tint = if (on) Color(0xFFFFD37A) else Color(0xFFE8ECF2)
                 val icon =
                     when {
@@ -185,7 +185,7 @@ class PictureElementsCard : CardRenderer {
                             Modifier
                                 .fillMaxWidth()
                                 .clip(RoundedCornerShape(20.dp))
-                                .background(Color(0xFF1B343D))
+                                .background(ctx.theme.cardSurface)
                                 .padding(14.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {

--- a/app/src/main/java/com/custom/astrion/cards/impl/PlexCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/PlexCard.kt
@@ -29,6 +29,7 @@ import com.custom.astrion.cards.CardConfig
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.ThemeColors
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -150,13 +151,13 @@ class PlexCard : CardRenderer {
                 Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(20.dp))
-                    .background(Color(0xFF1B343D))
+                    .background(ctx.theme.cardSurface)
                     .padding(vertical = 14.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text(
                 "Plex",
-                color = Color(0xFFE6F0F1),
+                color = ctx.theme.primaryText,
                 fontSize = 17.sp,
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.padding(horizontal = 14.dp),
@@ -165,14 +166,14 @@ class PlexCard : CardRenderer {
                 rows == null ->
                     Text(
                         "Loading…",
-                        color = Color(0xFF93AFB6),
+                        color = ctx.theme.mutedText,
                         fontSize = 13.sp,
                         modifier = Modifier.padding(horizontal = 14.dp),
                     )
                 error != null ->
                     Text(
                         error!!,
-                        color = Color(0xFFE0A0A0),
+                        color = ctx.theme.danger,
                         fontSize = 13.sp,
                         modifier = Modifier.padding(horizontal = 14.dp),
                     )
@@ -180,7 +181,7 @@ class PlexCard : CardRenderer {
                     rows!!.forEach { row ->
                         Text(
                             row.title,
-                            color = Color(0xFF93AFB6),
+                            color = ctx.theme.mutedText,
                             fontSize = 13.sp,
                             modifier = Modifier.padding(horizontal = 14.dp),
                         )
@@ -189,7 +190,7 @@ class PlexCard : CardRenderer {
                             contentPadding = PaddingValues(horizontal = 14.dp),
                         ) {
                             items(row.items) { item ->
-                                PosterTile(host, token, item) { play(item) }
+                                PosterTile(host, token, item, ctx.theme) { play(item) }
                             }
                         }
                     }
@@ -202,6 +203,7 @@ class PlexCard : CardRenderer {
         host: String,
         token: String,
         item: PlexItem,
+        theme: ThemeColors,
         onClick: () -> Unit,
     ) {
         Column(
@@ -240,19 +242,19 @@ class PlexCard : CardRenderer {
             if (bmp != null) {
                 Image(bmp!!, contentDescription = item.title, modifier = posterMod, contentScale = ContentScale.Crop)
             } else {
-                Box(posterMod.background(Color(0xFF152B33)))
+                Box(posterMod.background(theme.insetSurface))
             }
             Spacer(Modifier.height(4.dp))
             Text(
                 item.title,
-                color = Color(0xFFE6F0F1),
+                color = theme.primaryText,
                 fontSize = 12.sp,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )
             Text(
                 item.subtitle,
-                color = Color(0xFF93AFB6),
+                color = theme.mutedText,
                 fontSize = 10.sp,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/com/custom/astrion/cards/impl/SourceSelectCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/SourceSelectCard.kt
@@ -63,16 +63,16 @@ class SourceSelectCard : CardRenderer {
                     Modifier
                         .fillMaxWidth()
                         .clip(RoundedCornerShape(14.dp))
-                        .background(Color(0xFF1E3841))
+                        .background(ctx.theme.controlBackground)
                         .clickable(enabled = sources.isNotEmpty()) { expanded = true }
                         .padding(horizontal = 14.dp, vertical = 10.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Column(Modifier.weight(1f)) {
-                    Text(name, color = Color(0xFF93AFB6), fontSize = 11.sp)
+                    Text(name, color = ctx.theme.mutedText, fontSize = 11.sp)
                     Text(
                         current ?: if (sources.isEmpty()) "No sources (device off?)" else "Select source…",
-                        color = Color(0xFFE6F0F1),
+                        color = ctx.theme.primaryText,
                         fontSize = 15.sp,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
@@ -81,7 +81,7 @@ class SourceSelectCard : CardRenderer {
                 Icon(
                     Icons.Filled.ArrowDropDown,
                     contentDescription = null,
-                    tint = if (sources.isEmpty()) Color(0xFF5A7783) else Color(0xFFCBDCE0),
+                    tint = if (sources.isEmpty()) ctx.theme.mutedText else ctx.theme.iconTint,
                 )
             }
 
@@ -90,7 +90,7 @@ class SourceSelectCard : CardRenderer {
                 onDismissRequest = { expanded = false },
                 modifier =
                     Modifier
-                        .background(Color(0xFF1E3841))
+                        .background(ctx.theme.controlBackground)
                         .widthIn(max = 400.dp),
             ) {
                 sources.forEach { s ->
@@ -98,7 +98,7 @@ class SourceSelectCard : CardRenderer {
                         text = {
                             Text(
                                 s,
-                                color = if (s == current) Color(0xFF6EA8FE) else Color(0xFFE6F0F1),
+                                color = if (s == current) ctx.theme.accent else ctx.theme.primaryText,
                                 fontSize = 14.sp,
                                 maxLines = 2,
                                 overflow = TextOverflow.Ellipsis,

--- a/app/src/main/java/com/custom/astrion/cards/impl/SpeakerGroupCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/SpeakerGroupCard.kt
@@ -34,6 +34,7 @@ import com.custom.astrion.cards.CardConfig
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.ThemeColors
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
@@ -83,13 +84,13 @@ class SpeakerGroupCard : CardRenderer {
                 Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(18.dp))
-                    .background(Color(0xFF1B343D))
+                    .background(ctx.theme.cardSurface)
                     .padding(14.dp),
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
             Text(
                 "Speakers",
-                color = Color(0xFF93AFB6),
+                color = ctx.theme.mutedText,
                 fontSize = 13.sp,
                 fontWeight = FontWeight.SemiBold,
                 letterSpacing = 1.sp,
@@ -145,14 +146,14 @@ class SpeakerGroupCard : CardRenderer {
                     Icon(
                         Icons.Filled.Speaker,
                         contentDescription = null,
-                        tint = Color(0xFF6EA8FE),
+                        tint = ctx.theme.accent,
                         modifier = Modifier.size(24.dp),
                     )
                 } else {
                     Icon(
                         if (grouped) Icons.Filled.CheckCircle else Icons.Filled.RadioButtonUnchecked,
                         contentDescription = if (grouped) "Ungroup" else "Group",
-                        tint = if (grouped) Color(0xFF6EA8FE) else Color(0xFF5A7783),
+                        tint = if (grouped) ctx.theme.accent else ctx.theme.mutedText,
                         modifier =
                             Modifier
                                 .size(26.dp)
@@ -162,7 +163,7 @@ class SpeakerGroupCard : CardRenderer {
                 }
                 Text(
                     label,
-                    color = Color(0xFFE6F0F1),
+                    color = ctx.theme.primaryText,
                     fontSize = 15.sp,
                     fontWeight = FontWeight.SemiBold,
                     modifier = Modifier.weight(1f),
@@ -173,7 +174,7 @@ class SpeakerGroupCard : CardRenderer {
                         vol != null -> "${(vol * 100).roundToInt()}%"
                         else -> "—"
                     },
-                    color = if (muted) Color(0xFFE79A9A) else Color(0xFF93AFB6),
+                    color = if (muted) ctx.theme.danger else ctx.theme.mutedText,
                     fontSize = 12.sp,
                 )
             }
@@ -181,15 +182,15 @@ class SpeakerGroupCard : CardRenderer {
             VolumeBar(entityId, vol, muted, ctx)
             // Controls: mute / vol- / vol+.
             Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                SmallBtn(Icons.Filled.VolumeOff, active = muted) {
+                SmallBtn(Icons.Filled.VolumeOff, active = muted, theme = ctx.theme) {
                     ctx.client.callService(
                         ServiceCall.of("media_player", "volume_mute", entityId, "is_volume_muted" to !muted),
                     )
                 }
-                SmallBtn(Icons.Filled.VolumeDown) {
+                SmallBtn(Icons.Filled.VolumeDown, theme = ctx.theme) {
                     ctx.client.callService(ServiceCall("media_player", "volume_down", entityId))
                 }
-                SmallBtn(Icons.Filled.VolumeUp) {
+                SmallBtn(Icons.Filled.VolumeUp, theme = ctx.theme) {
                     ctx.client.callService(ServiceCall("media_player", "volume_up", entityId))
                 }
             }
@@ -246,14 +247,14 @@ class SpeakerGroupCard : CardRenderer {
                         .fillMaxWidth()
                         .height(8.dp)
                         .clip(RoundedCornerShape(4.dp))
-                        .background(Color(0xFF152B33)),
+                        .background(ctx.theme.insetSurface),
             ) {
                 Box(
                     modifier =
                         Modifier
                             .fillMaxWidth(dragLevel)
                             .fillMaxHeight()
-                            .background(if (muted) Color(0xFF5A7783) else Color(0xFF57C4A3)),
+                            .background(if (muted) ctx.theme.mutedText else ctx.theme.success),
                 )
             }
         }
@@ -262,6 +263,7 @@ class SpeakerGroupCard : CardRenderer {
     @Composable
     private fun SmallBtn(
         icon: ImageVector,
+        theme: ThemeColors,
         active: Boolean = false,
         onClick: () -> Unit,
     ) {
@@ -270,14 +272,14 @@ class SpeakerGroupCard : CardRenderer {
                 Modifier
                     .size(34.dp)
                     .clip(CircleShape)
-                    .background(if (active) Color(0xFF3A2E2E) else Color(0xFF2C4C58))
+                    .background(if (active) theme.danger.copy(alpha = 0.25f) else theme.controlBackground)
                     .clickable(onClick = onClick),
             contentAlignment = Alignment.Center,
         ) {
             Icon(
                 icon,
                 contentDescription = null,
-                tint = if (active) Color(0xFFE06767) else Color(0xFFCBDCE0),
+                tint = if (active) theme.danger else theme.iconTint,
                 modifier = Modifier.size(18.dp),
             )
         }

--- a/app/src/main/java/com/custom/astrion/cards/impl/SwitchCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/SwitchCard.kt
@@ -52,7 +52,7 @@ class SwitchCard : CardRenderer {
                 Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(18.dp))
-                    .background(if (on) onColor else Color(0xFF1E3841))
+                    .background(if (on) onColor else ctx.theme.controlBackground)
                     .clickable { ctx.client.toggle(entityId) }
                     .padding(14.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -63,17 +63,17 @@ class SwitchCard : CardRenderer {
                     Modifier
                         .size(42.dp)
                         .clip(RoundedCornerShape(12.dp))
-                        .background(Color(0xFF2A4954)),
+                        .background(ctx.theme.controlBackground),
                 contentAlignment = Alignment.Center,
             ) {
-                Icon(icon, contentDescription = null, tint = if (on) Color(0xFFE79A9A) else Color(0xFFB6C9CE))
+                Icon(icon, contentDescription = null, tint = if (on) ctx.theme.danger else ctx.theme.iconTint)
             }
             Spacer(Modifier.width(12.dp))
             Column(Modifier.weight(1f)) {
-                Text(name, color = Color(0xFFE6F0F1), fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
+                Text(name, color = ctx.theme.primaryText, fontSize = 16.sp, fontWeight = FontWeight.SemiBold)
                 Text(
                     if (on) stringResource(R.string.astrion_state_on) else stringResource(R.string.astrion_state_off),
-                    color = Color(0xFF93AFB6),
+                    color = ctx.theme.mutedText,
                     fontSize = 13.sp,
                 )
             }

--- a/app/src/main/java/com/custom/astrion/cards/impl/TitleCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/TitleCard.kt
@@ -106,7 +106,7 @@ class TitleCard : CardRenderer {
         val divider = remember(config) { config.bool("divider") }
         val titleColor =
             remember(config) {
-                config.string("color")?.let { parseHexColor(it) } ?: Color(0xFFCFCFCF)
+                config.string("color")?.let { parseHexColor(it) } ?: ctx.theme.primaryText
             }
         val iconBitmap =
             remember(iconPath) {
@@ -202,7 +202,7 @@ class TitleCard : CardRenderer {
             if (!subtitle.isNullOrBlank()) {
                 Text(
                     text = subtitle,
-                    color = Color(0xFF93AFB6),
+                    color = ctx.theme.mutedText,
                     fontSize = 14.sp,
                     fontWeight = FontWeight.Medium,
                     textAlign =

--- a/app/src/main/java/com/custom/astrion/cards/impl/TvRemoteCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/TvRemoteCard.kt
@@ -23,6 +23,7 @@ import com.custom.astrion.cards.CardConfig
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.ThemeColors
 
 /**
  * TV / Android-TV remote card.
@@ -117,7 +118,7 @@ class TvRemoteCard : CardRenderer {
                 Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(20.dp))
-                    .background(Color(0xFF1B343D))
+                    .background(ctx.theme.cardSurface)
                     .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
@@ -127,8 +128,8 @@ class TvRemoteCard : CardRenderer {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text(name, color = Color(0xFFE6F0F1), fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
-                RoundIconButton(Icons.Filled.PowerSettingsNew, tint = Color(0xFFE06767)) {
+                Text(name, color = ctx.theme.primaryText, fontSize = 18.sp, fontWeight = FontWeight.SemiBold)
+                RoundIconButton(Icons.Filled.PowerSettingsNew, ctx.theme, tint = ctx.theme.danger) {
                     send(c("power", "POWER"))
                 }
             }
@@ -140,6 +141,7 @@ class TvRemoteCard : CardRenderer {
                 onLeft = { send(c("left", "DPAD_LEFT")) },
                 onRight = { send(c("right", "DPAD_RIGHT")) },
                 onCenter = { send(c("center", "DPAD_CENTER")) },
+                theme = ctx.theme,
             )
 
             // Navigation row: back / home / menu
@@ -147,9 +149,9 @@ class TvRemoteCard : CardRenderer {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceEvenly,
             ) {
-                RoundIconButton(Icons.AutoMirrored.Filled.ArrowBack) { send(c("back", "BACK")) }
-                RoundIconButton(Icons.Filled.Home) { send(c("home", "HOME")) }
-                RoundIconButton(Icons.Filled.Menu) { send(c("menu", "MENU")) }
+                RoundIconButton(Icons.AutoMirrored.Filled.ArrowBack, ctx.theme) { send(c("back", "BACK")) }
+                RoundIconButton(Icons.Filled.Home, ctx.theme) { send(c("home", "HOME")) }
+                RoundIconButton(Icons.Filled.Menu, ctx.theme) { send(c("menu", "MENU")) }
             }
 
             // App-launch buttons, two per row.
@@ -162,6 +164,7 @@ class TvRemoteCard : CardRenderer {
                         AppButton(
                             label = app["name"] as? String ?: "App",
                             modifier = Modifier.weight(1f),
+                            theme = ctx.theme,
                         ) { launch(app) }
                     }
                     if (pair.size == 1) Spacer(Modifier.weight(1f))
@@ -174,6 +177,7 @@ class TvRemoteCard : CardRenderer {
     private fun AppButton(
         label: String,
         modifier: Modifier,
+        theme: ThemeColors,
         onClick: () -> Unit,
     ) {
         Box(
@@ -181,11 +185,11 @@ class TvRemoteCard : CardRenderer {
                 modifier
                     .height(48.dp)
                     .clip(RoundedCornerShape(12.dp))
-                    .background(Color(0xFF2C4C58))
+                    .background(theme.controlBackground)
                     .clickable(onClick = onClick),
             contentAlignment = Alignment.Center,
         ) {
-            Text(label, color = Color(0xFFE6F0F1), fontSize = 15.sp, fontWeight = FontWeight.Medium)
+            Text(label, color = theme.primaryText, fontSize = 15.sp, fontWeight = FontWeight.Medium)
         }
     }
 
@@ -206,6 +210,7 @@ class TvRemoteCard : CardRenderer {
         onLeft: () -> Unit,
         onRight: () -> Unit,
         onCenter: () -> Unit,
+        theme: ThemeColors,
     ) {
         Box(
             modifier =
@@ -213,24 +218,24 @@ class TvRemoteCard : CardRenderer {
                     .fillMaxWidth()
                     .height(180.dp)
                     .clip(RoundedCornerShape(90.dp))
-                    .background(Color(0xFF23414B)),
+                    .background(theme.controlBackground),
             contentAlignment = Alignment.Center,
         ) {
             // Up
             Box(Modifier.align(Alignment.TopCenter).padding(top = 12.dp)) {
-                RoundIconButton(Icons.Filled.KeyboardArrowUp, onClick = onUp)
+                RoundIconButton(Icons.Filled.KeyboardArrowUp, theme, onClick = onUp)
             }
             // Down
             Box(Modifier.align(Alignment.BottomCenter).padding(bottom = 12.dp)) {
-                RoundIconButton(Icons.Filled.KeyboardArrowDown, onClick = onDown)
+                RoundIconButton(Icons.Filled.KeyboardArrowDown, theme, onClick = onDown)
             }
             // Left
             Box(Modifier.align(Alignment.CenterStart).padding(start = 12.dp)) {
-                RoundIconButton(Icons.AutoMirrored.Filled.KeyboardArrowLeft, onClick = onLeft)
+                RoundIconButton(Icons.AutoMirrored.Filled.ArrowLeft, theme, onClick = onLeft)
             }
             // Right
             Box(Modifier.align(Alignment.CenterEnd).padding(end = 12.dp)) {
-                RoundIconButton(Icons.AutoMirrored.Filled.KeyboardArrowRight, onClick = onRight)
+                RoundIconButton(Icons.AutoMirrored.Filled.ArrowRight, theme, onClick = onRight)
             }
             // Center / OK
             Box(
@@ -238,7 +243,7 @@ class TvRemoteCard : CardRenderer {
                     Modifier
                         .size(64.dp)
                         .clip(CircleShape)
-                        .background(Color(0xFF33525E))
+                        .background(theme.controlBackground)
                         .clickable(onClick = onCenter),
                 contentAlignment = Alignment.Center,
             ) {
@@ -250,7 +255,8 @@ class TvRemoteCard : CardRenderer {
     @Composable
     private fun RoundIconButton(
         icon: ImageVector,
-        tint: Color = Color(0xFFCBDCE0),
+        theme: ThemeColors,
+        tint: Color = theme.iconTint,
         onClick: () -> Unit,
     ) {
         Box(
@@ -258,7 +264,7 @@ class TvRemoteCard : CardRenderer {
                 Modifier
                     .size(52.dp)
                     .clip(CircleShape)
-                    .background(Color(0xFF2C4C58))
+                    .background(theme.controlBackground)
                     .clickable(onClick = onClick),
             contentAlignment = Alignment.Center,
         ) {

--- a/app/src/main/java/com/custom/astrion/cards/impl/VacuumCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/VacuumCard.kt
@@ -44,6 +44,7 @@ import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.HaLabels
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.ThemeColors
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
 
@@ -89,7 +90,7 @@ class VacuumCard : CardRenderer {
                 Modifier
                     .fillMaxWidth()
                     .clip(RoundedCornerShape(20.dp))
-                    .background(Color(0xFF1B343D))
+                    .background(ctx.theme.cardSurface)
                     .padding(14.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
@@ -152,12 +153,12 @@ fun VacuumPanelContent(
     Row(verticalAlignment = Alignment.CenterVertically) {
         Text(
             name,
-            color = Color(0xFFE6F0F1),
+            color = ctx.theme.primaryText,
             fontSize = 16.sp,
             fontWeight = FontWeight.SemiBold,
             modifier = Modifier.weight(1f),
         )
-        Text(HaLabels.vacuumState(state), color = Color(0xFF93AFB6), fontSize = 13.sp)
+        Text(HaLabels.vacuumState(state), color = ctx.theme.mutedText, fontSize = 13.sp)
     }
 
     // Map (includes the robot, rooms, path — rendered by the integration).
@@ -169,7 +170,7 @@ fun VacuumPanelContent(
                     .fillMaxWidth()
                     .height(mapHeight.dp)
                     .clip(RoundedCornerShape(12.dp))
-                    .background(Color(0xFF0E2229)),
+                    .background(ctx.theme.background),
             contentAlignment = Alignment.Center,
         ) {
             Image(
@@ -186,10 +187,10 @@ fun VacuumPanelContent(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
     ) {
-        VacuumCtrlBtn(Icons.Filled.PlayArrow, accent = true) { vac("start") }
-        VacuumCtrlBtn(Icons.Filled.Pause) { vac("pause") }
-        VacuumCtrlBtn(Icons.Filled.Home) { vac("return_to_base") }
-        VacuumCtrlBtn(Icons.Filled.MyLocation) { vac("locate") }
+        VacuumCtrlBtn(Icons.Filled.PlayArrow, ctx.theme, accent = true) { vac("start") }
+        VacuumCtrlBtn(Icons.Filled.Pause, ctx.theme) { vac("pause") }
+        VacuumCtrlBtn(Icons.Filled.Home, ctx.theme) { vac("return_to_base") }
+        VacuumCtrlBtn(Icons.Filled.MyLocation, ctx.theme) { vac("locate") }
     }
 
     // Fan speed / cleaning mode dropdown.
@@ -200,28 +201,28 @@ fun VacuumPanelContent(
                     Modifier
                         .fillMaxWidth()
                         .clip(RoundedCornerShape(12.dp))
-                        .background(Color(0xFF1E3841))
+                        .background(ctx.theme.controlBackground)
                         .clickable { fanExpanded = true }
                         .padding(horizontal = 14.dp, vertical = 10.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Column(Modifier.weight(1f)) {
-                    Text(stringResource(R.string.vacuum_fan_speed_caption), color = Color(0xFF93AFB6), fontSize = 11.sp)
-                    Text(fanSpeed?.let(HaLabels::vacuumFanSpeed) ?: "—", color = Color(0xFFE6F0F1), fontSize = 15.sp)
+                    Text(stringResource(R.string.vacuum_fan_speed_caption), color = ctx.theme.mutedText, fontSize = 11.sp)
+                    Text(fanSpeed?.let(HaLabels::vacuumFanSpeed) ?: "—", color = ctx.theme.primaryText, fontSize = 15.sp)
                 }
-                Icon(Icons.Filled.ArrowDropDown, contentDescription = null, tint = Color(0xFFCBDCE0))
+                Icon(Icons.Filled.ArrowDropDown, contentDescription = null, tint = ctx.theme.iconTint)
             }
             DropdownMenu(
                 expanded = fanExpanded,
                 onDismissRequest = { fanExpanded = false },
-                modifier = Modifier.background(Color(0xFF1E3841)),
+                modifier = Modifier.background(ctx.theme.controlBackground),
             ) {
                 fanList.forEach { f ->
                     DropdownMenuItem(
                         text = {
                             Text(
                                 HaLabels.vacuumFanSpeed(f),
-                                color = if (f == fanSpeed) Color(0xFF6EA8FE) else Color(0xFFE6F0F1),
+                                color = if (f == fanSpeed) ctx.theme.accent else ctx.theme.primaryText,
                                 fontSize = 14.sp,
                             )
                         },
@@ -253,11 +254,11 @@ fun VacuumPanelContent(
                                 .weight(1f)
                                 .height(44.dp)
                                 .clip(RoundedCornerShape(12.dp))
-                                .background(Color(0xFF2A4954))
+                                .background(ctx.theme.controlBackground)
                                 .clickable(enabled = id != null) { id?.let { cleanSegment(it) } },
                         contentAlignment = Alignment.Center,
                     ) {
-                        Text(label, color = Color(0xFFE6F0F1), fontSize = 14.sp, fontWeight = FontWeight.Medium)
+                        Text(label, color = ctx.theme.primaryText, fontSize = 14.sp, fontWeight = FontWeight.Medium)
                     }
                 }
                 repeat(3 - chunk.size) { Spacer(Modifier.weight(1f)) }
@@ -269,6 +270,7 @@ fun VacuumPanelContent(
 @Composable
 private fun VacuumCtrlBtn(
     icon: ImageVector,
+    theme: ThemeColors,
     accent: Boolean = false,
     onClick: () -> Unit,
 ) {
@@ -277,7 +279,7 @@ private fun VacuumCtrlBtn(
             Modifier
                 .size(52.dp)
                 .clip(CircleShape)
-                .background(if (accent) Color(0xFF4C6EF5) else Color(0xFF2C4C58))
+                .background(if (accent) theme.accentSecondary else theme.controlBackground)
                 .clickable(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {

--- a/app/src/main/java/com/custom/astrion/config/AppConfig.kt
+++ b/app/src/main/java/com/custom/astrion/config/AppConfig.kt
@@ -31,6 +31,11 @@ data class AppConfig(
      * Single-device/single-action Activities don't need an entry here at
      * all — see the NOTE further down for that lighter-weight path. */
     val activities: List<ActivityConfig> = emptyList(),
+    /** Global color theme. Every UI color that was once a hardcoded literal
+     * reads from here (via ThemeColors / LocalTheme in the Compose layer).
+     * Missing fields fall back to the built-in defaults, so an empty `theme`
+     * block renders identically to the original look. */
+    val theme: ThemeConfig = ThemeConfig(),
 )
 
 /**
@@ -232,4 +237,26 @@ data class ActivityDeviceConfig(
      * the last device and on stop (power-off runs with no delays between
      * devices — nothing downstream needs to wait for it). */
     val delayAfterMs: Int = 0,
+)
+
+/**
+ * Global color theme — 12 semantic tokens. Values are ARGB/RGB hex strings
+ * (e.g. "#1B343D"). Each defaults to the app's original hardcoded color, so a
+ * ThemeConfig() with no overrides reproduces the built-in look exactly.
+ * Parsed from the `theme` block of dashboard.json by DashboardLoader.
+ */
+@Suppress("Unused")
+data class ThemeConfig(
+    val background: String = "#0E2229",
+    val cardSurface: String = "#1B343D",
+    val insetSurface: String = "#152B33",
+    val controlBackground: String = "#2C4C58",
+    val primaryText: String = "#E6F0F1",
+    val mutedText: String = "#93AFB6",
+    val iconTint: String = "#CBDCE0",
+    val accent: String = "#6EA8FE",
+    val accentSecondary: String = "#4C6EF5",
+    val amber: String = "#FFC24B",
+    val danger: String = "#E06767",
+    val success: String = "#4CAF50",
 )

--- a/app/src/main/java/com/custom/astrion/config/DashboardLoader.kt
+++ b/app/src/main/java/com/custom/astrion/config/DashboardLoader.kt
@@ -130,7 +130,8 @@ object DashboardLoader {
                 val longHotkeys = root["longHotkeys"]?.jsonArray?.map { parseHotkey(it.jsonObject) } ?: emptyList()
                 val irDevices = root["irDevices"]?.jsonArray?.map { parseIrDevice(it.jsonObject) } ?: emptyList()
                 val activities = root["activities"]?.jsonArray?.map { parseActivity(it.jsonObject) } ?: emptyList()
-                AppConfig(pages, start.coerceIn(0, pages.size - 1), hotkeys, longHotkeys, irDevices, activities)
+                val theme = root["theme"]?.jsonObject?.let { parseTheme(it) } ?: ThemeConfig()
+                AppConfig(pages, start.coerceIn(0, pages.size - 1), hotkeys, longHotkeys, irDevices, activities, theme)
             }
             else -> error("top level must be an object or array")
         }
@@ -223,6 +224,24 @@ object DashboardLoader {
         )
     }
 
+    private fun parseTheme(obj: JsonObject): ThemeConfig {
+        fun s(key: String, default: String) =
+            obj[key]?.jsonPrimitive?.takeIf { it.isString }?.content?.ifBlank { default } ?: default
+        return ThemeConfig(
+            background = s("background", ThemeConfig().background),
+            cardSurface = s("cardSurface", ThemeConfig().cardSurface),
+            insetSurface = s("insetSurface", ThemeConfig().insetSurface),
+            controlBackground = s("controlBackground", ThemeConfig().controlBackground),
+            primaryText = s("primaryText", ThemeConfig().primaryText),
+            mutedText = s("mutedText", ThemeConfig().mutedText),
+            iconTint = s("iconTint", ThemeConfig().iconTint),
+            accent = s("accent", ThemeConfig().accent),
+            accentSecondary = s("accentSecondary", ThemeConfig().accentSecondary),
+            amber = s("amber", ThemeConfig().amber),
+            danger = s("danger", ThemeConfig().danger),
+            success = s("success", ThemeConfig().success),
+        )
+    }
 
     // ---- serialize defaults -------------------------------------------------
 

--- a/app/src/main/java/com/custom/astrion/ui/Dashboard.kt
+++ b/app/src/main/java/com/custom/astrion/ui/Dashboard.kt
@@ -28,6 +28,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -121,6 +123,8 @@ fun Dashboard(
         HaLabels.init(context)
     }
     val connection by connectionState
+    val theme = remember(config.theme) { config.theme.toColors() }
+    ProvideTheme(theme) {
     // Status dot reflects the first configured hub — good enough for a single
     // glance indicator; a per-hub breakdown isn't worth the UI space here.
     val harmonyConnected by (harmonyRegistry.client()?.connected ?: remember { MutableStateFlow(false) }).collectAsState()
@@ -338,6 +342,7 @@ fun Dashboard(
         activities = activitiesById,
         startActivity = startActivity,
         activityRuntime = activityRuntime,
+        theme = theme,
     )
 
     // Hardware-button navigation: jump straight to the requested page, then
@@ -366,7 +371,7 @@ fun Dashboard(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Color(0xFF0E2229)),
+                .background(LocalTheme.current.background),
         ) {
             TopStatusBar(onSwipeDownToSettings = { showSettings = true })
             ConnectionBanner(connection)
@@ -411,6 +416,7 @@ fun Dashboard(
             )
         }
     }
+    }
 }
 
 /**
@@ -428,7 +434,7 @@ fun Dashboard(
  */
 @Composable
 private fun SettingsOverlay(ctx: CardContext, onClose: () -> Unit) {
-    Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0E2229))) {
+    Box(modifier = Modifier.fillMaxSize().background(LocalTheme.current.background)) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -439,7 +445,7 @@ private fun SettingsOverlay(ctx: CardContext, onClose: () -> Unit) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                 Text(
                     "✕ " + stringResource(R.string.close),
-                    color = Color(0xFF93AFB6),
+                    color = LocalTheme.current.mutedText,
                     fontSize = 13.sp,
                     modifier = Modifier
                         .clip(RoundedCornerShape(10.dp))
@@ -469,7 +475,7 @@ private fun SettingsOverlay(ctx: CardContext, onClose: () -> Unit) {
                     .width(40.dp)
                     .height(4.dp)
                     .clip(RoundedCornerShape(2.dp))
-                    .background(Color(0xFF3A5560)),
+                    .background(LocalTheme.current.controlBackground),
             )
         }
     }
@@ -499,7 +505,7 @@ private fun ActivitiesOverlay(
     val activeByRoom by activityRuntime.activeByRoom.collectAsState()
     val active = remember(activeByRoom) { activityRuntime.activeActivities() }
 
-    Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0E2229))) {
+    Box(modifier = Modifier.fillMaxSize().background(LocalTheme.current.background)) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -513,7 +519,7 @@ private fun ActivitiesOverlay(
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                 Text(
                     "✕ " + stringResource(R.string.close),
-                    color = Color(0xFF93AFB6),
+                    color = LocalTheme.current.mutedText,
                     fontSize = 13.sp,
                     modifier = Modifier
                         .clip(RoundedCornerShape(10.dp))
@@ -523,7 +529,7 @@ private fun ActivitiesOverlay(
             }
             Text(
                 stringResource(R.string.active_activities),
-                color = Color(0xFFCFCFCF),
+                color = LocalTheme.current.primaryText,
                 fontSize = 18.sp,
                 fontWeight = FontWeight.Medium,
                 modifier = Modifier.padding(horizontal = 10.dp),
@@ -531,7 +537,7 @@ private fun ActivitiesOverlay(
             if (active.isEmpty()) {
                 Text(
                     stringResource(R.string.no_active_activities),
-                    color = Color(0xFF6E8991),
+                    color = LocalTheme.current.mutedText,
                     fontSize = 13.sp,
                     modifier = Modifier.padding(10.dp),
                 )
@@ -539,7 +545,7 @@ private fun ActivitiesOverlay(
             active.groupBy { it.room }.forEach { (room, activities) ->
                 Text(
                     room,
-                    color = Color(0xFF6EA8FE),
+                    color = LocalTheme.current.accent,
                     fontSize = 13.sp,
                     fontWeight = FontWeight.Medium,
                     modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp),
@@ -549,7 +555,7 @@ private fun ActivitiesOverlay(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clip(RoundedCornerShape(10.dp))
-                            .background(Color(0xFF13262D))
+                            .background(LocalTheme.current.insetSurface)
                             .clickable(enabled = activity.page != null) {
                                 activity.page?.let { ctx.navigateToPage(it); onClose() }
                             }
@@ -557,7 +563,7 @@ private fun ActivitiesOverlay(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.SpaceBetween,
                     ) {
-                        Text(activity.name, color = Color(0xFFCFCFCF), fontSize = 15.sp)
+                        Text(activity.name, color = LocalTheme.current.primaryText, fontSize = 15.sp)
                         // Dedicated per-room stop — the missing piece this
                         // overlay didn't have before: previously the only
                         // way to end a classic Harmony Activity was a
@@ -567,7 +573,7 @@ private fun ActivitiesOverlay(
                         // only this Activity's own hub.
                         Text(
                             stringResource(R.string.stop_activity),
-                            color = Color(0xFFE5837E),
+                            color = LocalTheme.current.danger,
                             fontSize = 13.sp,
                             modifier = Modifier
                                 .clip(RoundedCornerShape(8.dp))
@@ -598,7 +604,7 @@ private fun ActivitiesOverlay(
                     .width(40.dp)
                     .height(4.dp)
                     .clip(RoundedCornerShape(2.dp))
-                    .background(Color(0xFF3A5560)),
+                    .background(LocalTheme.current.controlBackground),
             )
         }
     }
@@ -624,7 +630,7 @@ private fun PageContent(page: PageConfig, ctx: CardContext) {
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .background(Color(0xFF13262D))
+                    .background(LocalTheme.current.insetSurface)
                     .padding(horizontal = 10.dp, vertical = 8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
@@ -732,11 +738,11 @@ private fun PageIndicator(
                     .padding(horizontal = 8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Text("‹", color = Color(0xFF6EA8FE), fontSize = 18.sp, fontWeight = FontWeight.Bold)
+                Text("‹", color = LocalTheme.current.accent, fontSize = 18.sp, fontWeight = FontWeight.Bold)
                 Spacer(Modifier.width(4.dp))
                 Text(
                     currentPage.parent,
-                    color = Color(0xFF6EA8FE),
+                    color = LocalTheme.current.accent,
                     fontSize = 12.sp,
                     fontWeight = FontWeight.Medium,
                     maxLines = 1,
@@ -762,7 +768,7 @@ private fun PageIndicator(
                         .padding(horizontal = 5.dp)
                         .size(if (active) 10.dp else 8.dp)
                         .clip(CircleShape)
-                        .background(if (active) Color(0xFF6EA8FE) else Color(0xFF33525E))
+                        .background(if (active) LocalTheme.current.accent else LocalTheme.current.controlBackground)
                         .clickable { onDotClick(sibling.index) },
                 )
             }
@@ -774,7 +780,7 @@ private fun PageIndicator(
         // zone already owns that) to avoid saying it twice in one row.
         Text(
             text = currentPage?.name ?: "",
-            color = Color(0xFF93AFB6),
+            color = LocalTheme.current.mutedText,
             fontSize = 12.sp,
             fontWeight = FontWeight.Medium,
             maxLines = 1,
@@ -789,7 +795,7 @@ private fun PageIndicator(
  * how you get past the visible window. */
 @Composable
 private fun EdgeEllipsis() {
-    Text("…", color = Color(0xFF3A5560), fontSize = 12.sp, modifier = Modifier.padding(horizontal = 2.dp))
+    Text("…", color = LocalTheme.current.mutedText, fontSize = 12.sp, modifier = Modifier.padding(horizontal = 2.dp))
 }
 
 
@@ -798,10 +804,10 @@ private fun ConnectionBanner(connection: ConnectionState) {
     if (connection == ConnectionState.CONNECTED) return
     val (label, color) = when (connection) {
         ConnectionState.CONNECTING,
-        ConnectionState.AUTHENTICATING -> "Connecting…" to Color(0xFF3A506B)
-        ConnectionState.AUTH_FAILED -> "Auth failed — check token" to Color(0xFF7A2E2E)
-        ConnectionState.ERROR -> "Connection error — retrying" to Color(0xFF7A2E2E)
-        else -> "Disconnected" to Color(0xFF33525E)
+        ConnectionState.AUTHENTICATING -> "Connecting…" to LocalTheme.current.controlBackground
+        ConnectionState.AUTH_FAILED -> "Auth failed — check token" to LocalTheme.current.danger
+        ConnectionState.ERROR -> "Connection error — retrying" to LocalTheme.current.danger
+        else -> "Disconnected" to LocalTheme.current.controlBackground
     }
     Box(
         modifier = Modifier
@@ -819,10 +825,10 @@ private fun ConfigNoticeBanner(text: String) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .background(Color(0xFF4A3B1E))
+            .background(LocalTheme.current.amber.copy(alpha = 0.25f))
             .padding(10.dp),
     ) {
-        Text(text = text, color = Color(0xFFE8C77B), fontSize = 12.sp)
+        Text(text = text, color = LocalTheme.current.amber, fontSize = 12.sp)
     }
 }
 
@@ -831,9 +837,9 @@ private fun UnknownCard(type: String) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .background(Color(0xFF2A2030))
+            .background(LocalTheme.current.cardSurface)
             .padding(14.dp),
     ) {
-        Text(text = "Unknown card type: \"$type\"", color = Color(0xFFE0A0A0), fontSize = 13.sp)
+        Text(text = "Unknown card type: \"$type\"", color = LocalTheme.current.danger, fontSize = 13.sp)
     }
 }

--- a/app/src/main/java/com/custom/astrion/ui/SettingsMenu.kt
+++ b/app/src/main/java/com/custom/astrion/ui/SettingsMenu.kt
@@ -64,13 +64,13 @@ fun SettingsMenu(ctx: CardContext) {
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(18.dp))
-            .background(Color(0xFF161616))
+            .background(LocalTheme.current.cardSurface)
             .padding(18.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp),
     ) {
         Text(
             stringResource(R.string.settings_title),
-            color = Color(0xFFE6E6E6),
+            color = LocalTheme.current.primaryText,
             fontSize = 16.sp,
             fontWeight = FontWeight.SemiBold,
         )
@@ -78,7 +78,7 @@ fun SettingsMenu(ctx: CardContext) {
         localIpAddress()?.let { ip ->
             Text(
                 if (ctx.configServerEnabled) "Local config: http://$ip:8080" else stringResource(R.string.config_server_off_hint),
-                color = if (ctx.configServerEnabled) Color(0xFF6EA8FE) else Color(0xFF9A9A9A),
+                color = if (ctx.configServerEnabled) LocalTheme.current.accent else LocalTheme.current.mutedText,
                 fontSize = 12.sp,
             )
         }
@@ -130,7 +130,7 @@ private fun ConnectionStatusRow(label: String, connected: Boolean, detail: Strin
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
-            .background(Color(0xFF232323))
+            .background(LocalTheme.current.controlBackground)
             .padding(horizontal = 14.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
@@ -139,11 +139,11 @@ private fun ConnectionStatusRow(label: String, connected: Boolean, detail: Strin
             modifier = Modifier
                 .size(10.dp)
                 .clip(CircleShape)
-                .background(if (connected) Color(0xFF4CAF50) else Color(0xFFE53935))
+                .background(if (connected) LocalTheme.current.success else LocalTheme.current.danger)
         )
-        Text(label, color = Color(0xFFCFCFCF), fontSize = 14.sp)
+        Text(label, color = LocalTheme.current.primaryText, fontSize = 14.sp)
         Spacer(Modifier.weight(1f))
-        Text(detail, color = Color(0xFF9A9A9A), fontSize = 13.sp)
+        Text(detail, color = LocalTheme.current.mutedText, fontSize = 13.sp)
     }
 }
 
@@ -161,10 +161,10 @@ private fun BrightnessSlider(activity: Activity?) {
 
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-            Icon(Icons.Filled.BrightnessMedium, contentDescription = null, tint = Color(0xFF9A9A9A))
-            Text(stringResource(R.string.brightness), color = Color(0xFFCFCFCF), fontSize = 14.sp)
+            Icon(Icons.Filled.BrightnessMedium, contentDescription = null, tint = LocalTheme.current.mutedText)
+            Text(stringResource(R.string.brightness), color = LocalTheme.current.primaryText, fontSize = 14.sp)
             Spacer(Modifier.weight(1f))
-            Text("${(brightness / 255f * 100).toInt()}%", color = Color(0xFF9A9A9A), fontSize = 13.sp)
+            Text("${(brightness / 255f * 100).toInt()}%", color = LocalTheme.current.mutedText, fontSize = 13.sp)
         }
 
         if (!canWrite) {
@@ -195,9 +195,9 @@ private fun BrightnessSlider(activity: Activity?) {
                     }
                 },
                 colors = SliderDefaults.colors(
-                    thumbColor = Color(0xFF6EA8FE),
-                    activeTrackColor = Color(0xFF6EA8FE),
-                    inactiveTrackColor = Color(0xFF2A2A2A),
+                    thumbColor = LocalTheme.current.accent,
+                    activeTrackColor = LocalTheme.current.accent,
+                    inactiveTrackColor = LocalTheme.current.controlBackground,
                 ),
             )
         }
@@ -211,13 +211,13 @@ private fun WakeOnMotionRow(ctx: CardContext) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        Icon(Icons.Filled.Vibration, contentDescription = null, tint = Color(0xFF9A9A9A))
-        Text(stringResource(R.string.wake_on_motion), color = Color(0xFFCFCFCF), fontSize = 14.sp)
+        Icon(Icons.Filled.Vibration, contentDescription = null, tint = LocalTheme.current.mutedText)
+        Text(stringResource(R.string.wake_on_motion), color = LocalTheme.current.primaryText, fontSize = 14.sp)
         Spacer(Modifier.weight(1f))
         Switch(
             checked = ctx.wakeOnMotionEnabled,
             onCheckedChange = { ctx.setWakeOnMotionEnabled(it) },
-            colors = SwitchDefaults.colors(checkedTrackColor = Color(0xFF6EA8FE)),
+            colors = SwitchDefaults.colors(checkedTrackColor = LocalTheme.current.accent),
         )
     }
 }
@@ -239,18 +239,18 @@ private fun ConfigServerRow(ctx: CardContext) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
-            Icon(Icons.Filled.Wifi, contentDescription = null, tint = Color(0xFF9A9A9A))
-            Text(stringResource(R.string.config_server_toggle), color = Color(0xFFCFCFCF), fontSize = 14.sp)
+            Icon(Icons.Filled.Wifi, contentDescription = null, tint = LocalTheme.current.mutedText)
+            Text(stringResource(R.string.config_server_toggle), color = LocalTheme.current.primaryText, fontSize = 14.sp)
             Spacer(Modifier.weight(1f))
             Switch(
                 checked = ctx.configServerEnabled,
                 onCheckedChange = { ctx.setConfigServerEnabled(it) },
-                colors = SwitchDefaults.colors(checkedTrackColor = Color(0xFF6EA8FE)),
+                colors = SwitchDefaults.colors(checkedTrackColor = LocalTheme.current.accent),
             )
         }
         Text(
             stringResource(R.string.config_server_toggle_hint),
-            color = Color(0xFF7A7A7A),
+            color = LocalTheme.current.mutedText,
             fontSize = 11.sp,
         )
     }
@@ -262,14 +262,14 @@ private fun SettingRow(icon: ImageVector?, label: String, onClick: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
-            .background(Color(0xFF232323))
+            .background(LocalTheme.current.controlBackground)
             .clickable(onClick = onClick)
             .padding(horizontal = 14.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        icon?.let { Icon(it, contentDescription = null, tint = Color(0xFF9A9A9A)) }
-        Text(label, color = Color(0xFFCFCFCF), fontSize = 14.sp)
+        icon?.let { Icon(it, contentDescription = null, tint = LocalTheme.current.mutedText) }
+        Text(label, color = LocalTheme.current.primaryText, fontSize = 14.sp)
     }
 }
 

--- a/app/src/main/java/com/custom/astrion/ui/Theme.kt
+++ b/app/src/main/java/com/custom/astrion/ui/Theme.kt
@@ -1,0 +1,91 @@
+package com.custom.astrion.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+import com.custom.astrion.config.ThemeConfig
+
+/**
+ * Resolved Compose colors for the whole dashboard — every UI surface that used
+ * to be a hardcoded `Color(0x...)` literal now reads from here.
+ *
+ * Obtained from a [ThemeConfig] (the JSON-driven `theme` block) via
+ * [ThemeConfig.toColors]. A default [LocalTheme] is provided so previews and
+ * any code path outside the dashboard still get the original palette.
+ *
+ * The 12 fields map 1:1 to the editor's semantic tokens (see docs/js/theme.js):
+ * background, cardSurface, insetSurface, controlBackground, primaryText,
+ * mutedText, iconTint, accent, accentSecondary, amber, danger, success.
+ */
+data class ThemeColors(
+    val background: Color,
+    val cardSurface: Color,
+    val insetSurface: Color,
+    val controlBackground: Color,
+    val primaryText: Color,
+    val mutedText: Color,
+    val iconTint: Color,
+    val accent: Color,
+    val accentSecondary: Color,
+    val amber: Color,
+    val danger: Color,
+    val success: Color,
+) {
+    companion object {
+        /** The app's original hardcoded palette — used when no theme is
+         * configured (empty `theme` block) and as the CompositionLocal default. */
+        val Default: ThemeColors = ThemeConfig().toColors()
+    }
+}
+
+/** Parses a hex color string ("#RRGGBB" or "#AARRGGBB" or "RRGGBB") into a
+ * Compose [Color]. Falls back to [fallback] on any parse failure so a bad
+ * value in dashboard.json never crashes the UI. */
+fun parseHexColor(hex: String?, fallback: Color): Color {
+    if (hex.isNullOrBlank()) return fallback
+    var s = hex.trim()
+    if (s.startsWith("#")) s = s.substring(1)
+    return try {
+        when (s.length) {
+            6 -> Color(("FF$s").toLong(16))
+            8 -> Color(s.toLong(16))
+            else -> fallback
+        }
+    } catch (e: Exception) {
+        fallback
+    }
+}
+
+/** Converts the JSON [ThemeConfig] into resolved Compose colors, falling back
+ * to each token's own default when a field is missing/invalid. */
+fun ThemeConfig.toColors(): ThemeColors {
+    val d = ThemeConfig()
+    return ThemeColors(
+        background = parseHexColor(background, parseHexColor(d.background, Color.Black)),
+        cardSurface = parseHexColor(cardSurface, parseHexColor(d.cardSurface, Color.Black)),
+        insetSurface = parseHexColor(insetSurface, parseHexColor(d.insetSurface, Color.Black)),
+        controlBackground = parseHexColor(controlBackground, parseHexColor(d.controlBackground, Color.Black)),
+        primaryText = parseHexColor(primaryText, parseHexColor(d.primaryText, Color.White)),
+        mutedText = parseHexColor(mutedText, parseHexColor(d.mutedText, Color.White)),
+        iconTint = parseHexColor(iconTint, parseHexColor(d.iconTint, Color.White)),
+        accent = parseHexColor(accent, parseHexColor(d.accent, Color.White)),
+        accentSecondary = parseHexColor(accentSecondary, parseHexColor(d.accentSecondary, Color.White)),
+        amber = parseHexColor(amber, parseHexColor(d.amber, Color.White)),
+        danger = parseHexColor(danger, parseHexColor(d.danger, Color.White)),
+        success = parseHexColor(success, parseHexColor(d.success, Color.White)),
+    )
+}
+
+/**
+ * CompositionLocal carrying the active [ThemeColors]. Provided once by
+ * [Dashboard] from the parsed config; read anywhere via
+ * `LocalTheme.current.<token>`. Defaults to [ThemeColors.Default] so
+ * composables render correctly even without a provider.
+ */
+val LocalTheme = staticCompositionLocalOf { ThemeColors.Default }
+
+/** Provides [theme] to descendants via [LocalTheme]. */
+@Composable
+fun ProvideTheme(theme: ThemeColors, content: @Composable () -> Unit) {
+    androidx.compose.runtime.CompositionLocalProvider(LocalTheme provides theme) { content() }
+}

--- a/app/src/main/java/com/custom/astrion/ui/Topstatusbar.kt
+++ b/app/src/main/java/com/custom/astrion/ui/Topstatusbar.kt
@@ -96,12 +96,12 @@ fun TopStatusBar(onSwipeDownToSettings: () -> Unit) {
             modifier = Modifier.fillMaxWidth(),
             contentAlignment = Alignment.Center,
         ) {
-            Text(time, color = Color(0xFFCFCFCF), fontSize = 13.sp, fontWeight = FontWeight.Medium)
+            Text(time, color = LocalTheme.current.primaryText, fontSize = 13.sp, fontWeight = FontWeight.Medium)
 
             Icon(
                 imageVector = if (wifiConnected) Icons.Filled.Wifi else Icons.Filled.WifiOff,
                 contentDescription = null,
-                tint = Color(0xFF93AFB6),
+                tint = LocalTheme.current.mutedText,
                 modifier = Modifier.size(16.dp).align(Alignment.CenterStart),
             )
 
@@ -111,7 +111,7 @@ fun TopStatusBar(onSwipeDownToSettings: () -> Unit) {
             ) {
                 BatteryGlyph(percent = batteryPct, charging = charging)
                 Spacer(Modifier.padding(end = 2.dp))
-                Text("$batteryPct%", color = Color(0xFF93AFB6), fontSize = 12.sp)
+                Text("$batteryPct%", color = LocalTheme.current.mutedText, fontSize = 12.sp)
             }
         }
     }
@@ -124,11 +124,12 @@ private fun BatteryGlyph(
     percent: Int,
     charging: Boolean,
 ) {
+    val theme = LocalTheme.current
     val fillColor =
         when {
-            charging -> Color(0xFF4CAF50)
-            percent <= 15 -> Color(0xFFE53935)
-            else -> Color(0xFF93AFB6)
+            charging -> theme.success
+            percent <= 15 -> theme.danger
+            else -> theme.mutedText
         }
     Canvas(modifier = Modifier.size(width = 20.dp, height = 11.dp)) {
         val bodyWidth = size.width * 0.85f
@@ -136,13 +137,13 @@ private fun BatteryGlyph(
         val strokeWidth = 1.2.dp.toPx()
 
         drawRoundRect(
-            color = Color(0xFF93AFB6),
+            color = theme.mutedText,
             topLeft = Offset(0f, 0f),
             size = Size(bodyWidth, size.height),
             style = Stroke(width = strokeWidth),
         )
         drawRoundRect(
-            color = Color(0xFF93AFB6),
+            color = theme.mutedText,
             topLeft = Offset(bodyWidth + 1.dp.toPx(), size.height * 0.25f),
             size = Size(nubWidth - 1.dp.toPx(), size.height * 0.5f),
         )

--- a/docs/index.html
+++ b/docs/index.html
@@ -124,7 +124,10 @@
       <div id="activitiesList" style="margin-top:12px"></div>
     </div>
 
-    <h2>4. Generated JSON</h2>
+    <h2>4. Theme & Colors</h2>
+    <div class="section-box" id="themeBox"></div>
+
+    <h2>5. Generated JSON</h2>
     <textarea id="jsonOutput" readonly></textarea>
     <div class="btn-row">
       <button onclick="copyJson()">Copy JSON</button>
@@ -367,6 +370,7 @@
 <script src="js/hotkeys.js"></script>
 <script src="js/ir.js"></script>
 <script src="js/activities.js"></script>
+<script src="js/theme.js"></script>
 <script src="js/export.js"></script>
 <script src="js/preview.js"></script>
 <script src="js/device.js"></script>

--- a/docs/js/cards.js
+++ b/docs/js/cards.js
@@ -1,6 +1,6 @@
 // ---- Cards ---------------------------------------------------------------
 
-const NAME_ENTITY_TYPES = ['switch', 'source_select'];
+const NAME_ENTITY_TYPES = ['source_select'];
 
 function updateCardFormInputs() {
   const type = document.getElementById('cardTypeSelect').value;
@@ -27,6 +27,13 @@ function updateCardFormInputs() {
       <label class="inline-check"><input type="checkbox" id="optTitleDivider"> Divider line (fills the rest of the row after the title)</label>
       <label>Color (optional, ARGB/RGB hex — defaults to the standard title color, also tints the divider line)</label><input type="text" id="optTitleColor" placeholder="#7FB3C4">
       <div class="hint">A section header for grouping the cards below it — no entity of its own. Setting an icon or the divider always left-aligns the title row regardless of Alignment (that layout has no sensible centered/right-aligned form) — the subtitle below is unaffected. For a tappable title/subtitle (e.g. a "see all" link to another page), use "Other / custom type…" below instead and add title_page / subtitle_page — or any of scene_grid's other action fields with a title_/subtitle_ prefix — directly in the JSON; like every type here, re-saving through this simple form overwrites the card's options from scratch, so those fields wouldn't survive a later edit through it.</div>
+    `;
+  } else if (type === 'switch') {
+    container.innerHTML = `
+      <label>Name</label><input type="text" id="optName" placeholder="e.g., Living Room">
+      <label>Entity ID</label><input type="text" id="optEntityId" placeholder="e.g., switch.living_room">
+      <label>"On" color (optional, ARGB hex — defaults to green)</label>${colorFieldHtml('optOnColor', '', '#FF2E5A46')}
+      ${iconFieldHtml('optIcon')}
     `;
   } else if (type === 'cover') {
     container.innerHTML = `
@@ -191,7 +198,7 @@ function updateCardFormInputs() {
             ${(dashboardData.activities || []).map(a => `<option value="${a.id}">${a.name} (${a.room})</option>`).join('')}
           </select>
           ${(dashboardData.activities || []).length === 0 ? '<div class="hint">No Activities yet — create one in the "Activities" section below for multi-device setups (e.g. IR-only, no Harmony/HA).</div>' : ''}
-          <label>Color (optional, ARGB hex — defaults to the standard tile color)</label><input type="text" id="giColor" placeholder="#66009688">
+          <label>Color (optional, ARGB hex — defaults to the standard tile color)</label>${colorFieldHtml('giColor', '', '#66009688')}
           <div class="divider" style="margin:12px 0"></div>
           <label><input type="checkbox" id="giTrack" onchange="onGiTrackChange()"> Track as Activity</label>
           <div class="hint">Makes this tile show up as the active AV Activity for its room — see ActivityRuntime. At most one tracked Activity is active per room at a time. Not needed if you picked a Composed Activity above — that's always tracked automatically, using its own room.</div>
@@ -354,7 +361,7 @@ function fillGridItemForm(type, item) {
     }
     const actRefSel = document.getElementById('giActivityRef');
     if (actRefSel) actRefSel.value = item.activity || '';
-    document.getElementById('giColor').value = item.color || '';
+    setColorFieldValue('giColor', item.color || '');
     document.getElementById('giTrack').checked = item.track === true;
     document.getElementById('giRoom').value = item.room || '';
     document.getElementById('giDevices').value = (item.devices || []).join(', ');
@@ -411,10 +418,11 @@ function cancelGridItemEdit() {
   document.getElementById('giName').value = '';
   document.getElementById('giIcon').value = '';
   updateIconThumb('giIcon');
-  ['giService', 'giEntityId', 'giData', 'giPage', 'giIrDevice', 'giIrCommand', 'giActivityRef', 'giColor'].forEach(id => {
+  ['giService', 'giEntityId', 'giData', 'giPage', 'giIrDevice', 'giIrCommand', 'giActivityRef'].forEach(id => {
     const el = document.getElementById(id);
     if (el) el.value = '';
   });
+  setColorFieldValue('giColor', '');
   const trackEl = document.getElementById('giTrack');
   if (trackEl) { trackEl.checked = false; document.getElementById('giRoom').value = ''; document.getElementById('giDevices').value = ''; onGiTrackChange(); }
   const harmonyModeSel = document.getElementById('giHarmonyMode');
@@ -443,7 +451,7 @@ function addGridItem(type) {
     const irDevice = document.getElementById('giIrDevice')?.value || '';
     const irCommand = document.getElementById('giIrCommand')?.value || '';
     const activityRef = document.getElementById('giActivityRef')?.value || '';
-    const color = document.getElementById('giColor').value.trim();
+    const color = colorFieldValue('giColor');
     if (entityId) item.entity_id = entityId;
     if (page) item.page = page;
     if (irDevice && irCommand) { item.irDevice = irDevice; item.irCommand = irCommand; }
@@ -581,6 +589,12 @@ function fillCardForm(card) {
     updateIconThumb('optTitleIcon');
     document.getElementById('optTitleDivider').checked = o.divider === true;
     document.getElementById('optTitleColor').value = o.color || '';
+  } else if (type === 'switch') {
+    document.getElementById('optName').value = o.name || '';
+    document.getElementById('optEntityId').value = o.entity_id || '';
+    setColorFieldValue('optOnColor', o.on_color || '');
+    document.getElementById('optIcon').value = o.icon || '';
+    updateIconThumb('optIcon');
   } else if (type === 'cover') {
     document.getElementById('optName').value = o.name || '';
     document.getElementById('optEntityId').value = o.entity_id || '';
@@ -728,6 +742,13 @@ function addCardToPage() {
     if (document.getElementById('optTitleDivider').checked) newCard.options.divider = true;
     const titleColor = document.getElementById('optTitleColor').value.trim();
     if (titleColor) newCard.options.color = titleColor;
+  } else if (type === 'switch') {
+    newCard.options.name = document.getElementById('optName').value || 'Switch';
+    newCard.options.entity_id = document.getElementById('optEntityId').value || 'switch.entity';
+    const onColor = colorFieldValue('optOnColor');
+    if (onColor) newCard.options.on_color = onColor;
+    const icon = document.getElementById('optIcon').value.trim();
+    if (icon) newCard.options.icon = icon;
   } else if (type === 'cover') {
     const coverName = document.getElementById('optName').value.trim();
     if (coverName) newCard.options.name = coverName;

--- a/docs/js/device.js
+++ b/docs/js/device.js
@@ -39,6 +39,7 @@ function applyParsedDashboard(parsed) {
     longHotkeys: parsed.longHotkeys || [],
     irDevices: parsed.irDevices || [],
     activities: parsed.activities || [],
+    theme: parsed.theme || {},
   };
   if (dashboardData.pages.length === 0) {
     dashboardData.pages.push({ name: "Home", cards: [], hotkeys: [], longHotkeys: [] });

--- a/docs/js/pages.js
+++ b/docs/js/pages.js
@@ -1,4 +1,4 @@
-let dashboardData = { startPage: 0, pages: [ { name: "Home", cards: [], hotkeys: [], longHotkeys: [] } ], hotkeys: [], longHotkeys: [], irDevices: [], activities: [] };
+let dashboardData = { startPage: 0, pages: [ { name: "Home", cards: [], hotkeys: [], longHotkeys: [] } ], hotkeys: [], longHotkeys: [], irDevices: [], activities: [], theme: {} };
 let currentActivePage = 0;
 let editingCard = null;    // index of the card being edited within the current page, or null
 let editingHotkey = null;  // { scope, listType, i } of the hotkey being edited, or null
@@ -25,7 +25,7 @@ function slugify(name, fallbackPrefix) {
 }
 
 function resetAll() {
-  dashboardData = { startPage: 0, pages: [ { name: "Home", cards: [], hotkeys: [], longHotkeys: [] } ], hotkeys: [], longHotkeys: [], irDevices: [], activities: [] };
+  dashboardData = { startPage: 0, pages: [ { name: "Home", cards: [], hotkeys: [], longHotkeys: [] } ], hotkeys: [], longHotkeys: [], irDevices: [], activities: [], theme: {} };
   currentActivePage = 0;
   document.getElementById('importBox').value = '';
   initEditor();
@@ -49,6 +49,7 @@ function importJson() {
       longHotkeys: parsed.longHotkeys || [],
       irDevices: parsed.irDevices || [],
       activities: parsed.activities || [],
+      theme: parsed.theme || {},
     };
     if (dashboardData.pages.length === 0) dashboardData.pages.push({ name: "Home", cards: [], hotkeys: [], longHotkeys: [] });
     currentActivePage = 0;
@@ -68,6 +69,8 @@ function initEditor() {
   renderHotkeysList();
   renderIrDevicesList();
   renderActivitiesList();
+  if (typeof renderThemeForm === 'function') renderThemeForm();
+  if (typeof applyThemeToPreview === 'function') applyThemeToPreview();
   updateJsonOutput();
   updateHotkeyActionInputs();
 }

--- a/docs/js/preview.js
+++ b/docs/js/preview.js
@@ -367,8 +367,8 @@ function renderPreview() {
       const cycleBtnHtml = enabledControls.length > 1 ? `<div class="pc-cycle-btn" title="Cycles through: ${enabledControls.join(', ')}">${mdiSvg(MDI.chevronRight)}</div>` : '';
       const controlsHtml = (full) => {
         let inner;
-        if (activeControl === 'position') inner = sliderHtml(position, '#6FA8DC');
-        else if (activeControl === 'tilt') inner = sliderHtml(tilt, '#8FBF7F');
+        if (activeControl === 'position') inner = sliderHtml(position, 'var(--accent)');
+        else if (activeControl === 'tilt') inner = sliderHtml(tilt, 'var(--success)');
         else if (activeControl === 'buttons') inner = buttonsHtml(full);
         else return '';
         return `<div style="display:flex; align-items:center; gap:8px; width:100%;"><div style="flex:1; min-width:0;">${inner}</div>${cycleBtnHtml}</div>`;
@@ -484,8 +484,8 @@ function renderPreview() {
       const [r, g, b] = LIGHT_MOCK.rgb_color || kelvinToPreviewRgb(LIGHT_MOCK.color_temp_kelvin);
       const lightColorCss = (isOn && useLightColor) ? `rgb(${r},${g},${b})` : null;
       const iconPath = isOn ? MDI.lightbulbOn : MDI.lightbulbOff;
-      const iconBg = !isOn ? '#2A4954' : (lightColorCss ? `rgba(${r},${g},${b},0.22)` : '#FFC24B');
-      const iconTint = !isOn ? '#B6C9CE' : (lightColorCss || '#241A00');
+      const iconBg = !isOn ? 'var(--control)' : (lightColorCss ? `rgba(${r},${g},${b},0.22)` : 'var(--amber)');
+      const iconTint = !isOn ? 'var(--icon)' : (lightColorCss || '#241A00');
       const barColor = lightColorCss || '#FFC24B';
 
       // Mirrors LightCard.kt: if none of the 3 flags are set at all, fall
@@ -611,10 +611,10 @@ function renderPreview() {
             </div>
             <div style="width:100%">
               <div class="pm-progress"><div class="pm-progress-fill" style="width:${fraction * 100}%"></div></div>
-              <div style="display:flex; justify-content:space-between; margin-top:4px;"><small style="color:#93AFB6">${fmtTime(mock.media_position)}</small><small style="color:#93AFB6">${fmtTime(mock.media_duration)}</small></div>
+              <div style="display:flex; justify-content:space-between; margin-top:4px;"><small style="color:var(--muted)">${fmtTime(mock.media_position)}</small><small style="color:var(--muted)">${fmtTime(mock.media_duration)}</small></div>
             </div>
             ${mediaButtons.length ? `<div class="pm-full-controls">${mediaButtons.map(b => btnHtml(b, true, true)).join('')}</div>` : ''}
-            ${(volumeButtons.length || hasVolumeSlider) ? `<div class="pm-full-controls">${hasVolumeSlider ? '<div style="flex:1; height:8px; border-radius:4px; background:#152B33; margin:0 8px;"><div style="width:' + Math.round((mock.volume_level || 0) * 100) + '%; height:100%; border-radius:4px; background:#4C6EF5;"></div></div>' : ''}${volumeButtons.map(b => btnHtml(b, true, false)).join('')}</div>` : ''}
+            ${(volumeButtons.length || hasVolumeSlider) ? `<div class="pm-full-controls">${hasVolumeSlider ? '<div style="flex:1; height:8px; border-radius:4px; background:var(--inset); margin:0 8px;"><div style="width:' + Math.round((mock.volume_level || 0) * 100) + '%; height:100%; border-radius:4px; background:var(--accent2);"></div></div>' : ''}${volumeButtons.map(b => btnHtml(b, true, false)).join('')}</div>` : ''}
           </div>`;
       } else {
         const hasMediaGroup = mediaButtons.length > 0;
@@ -636,7 +636,7 @@ function renderPreview() {
             </div>
             ${(hasMediaGroup || hasVolumeGroup) ? `
             <div class="pm-controls">
-              ${showingVolume && hasVolumeSlider ? '<div style="flex:1; height:36px; border-radius:10px; background:#152B33;"><div style="width:' + Math.round((mock.volume_level || 0) * 100) + '%; height:100%; border-radius:10px; background:#4C6EF5;"></div></div>' : ''}
+              ${showingVolume && hasVolumeSlider ? '<div style="flex:1; height:36px; border-radius:10px; background:var(--inset);"><div style="width:' + Math.round((mock.volume_level || 0) * 100) + '%; height:100%; border-radius:10px; background:var(--accent2);"></div></div>' : ''}
               ${activeButtons.map(b => btnHtml(b, false, true)).join('')}
               ${(hasMediaGroup && hasVolumeGroup) ? `<div class="pm-btn pm-swap">${mdiSvg(showingVolume ? MDI.play : MDI.volumeHigh)}</div>` : ''}
             </div>` : ''}
@@ -665,7 +665,7 @@ function renderPreview() {
         const label = item.name || '?';
         const src = iconUrl(item.icon);
         if (isScene) {
-          const bg = parseHexColorCss(item.color) || '#2A4954';
+          const bg = parseHexColorCss(item.color) || (typeof themeValues === 'function' ? themeValues().controlBackground : '#2C4C58');
           const textColor = textColorForBg(bg);
           const iconCell = hasIconGrid
             ? (src

--- a/docs/js/theme.js
+++ b/docs/js/theme.js
@@ -1,0 +1,280 @@
+// ---- Theme & Colors ---------------------------------------------------------
+//
+// Global dashboard theme: 12 semantic color tokens stored in
+// dashboardData.theme. The editor preview reflects changes live by setting
+// CSS variables on the .remote-screen node (the preview surface), which the
+// card renderer styles in styles.css consume via var(--token). On save,
+// updateJsonOutput() serializes dashboardData.theme into dashboard.json
+// automatically — no separate save step.
+
+// Token definitions: key (JSON/CSS), label, default hex (matches the app's
+// compiled-in ThemeConfig defaults so an untouched theme renders identically).
+const THEME_TOKENS = [
+  { group: 'Backgrounds', items: [
+    { key: 'background',       label: 'Window background',  default: '#0E2229' },
+    { key: 'cardSurface',      label: 'Card surface',       default: '#1B343D' },
+    { key: 'insetSurface',     label: 'Inset / recessed',   default: '#152B33' },
+    { key: 'controlBackground',label: 'Control / button',   default: '#2C4C58' },
+  ]},
+  { group: 'Text & Icons', items: [
+    { key: 'primaryText',      label: 'Primary text',       default: '#E6F0F1' },
+    { key: 'mutedText',        label: 'Muted text',         default: '#93AFB6' },
+    { key: 'iconTint',         label: 'Icon tint',          default: '#CBDCE0' },
+  ]},
+  { group: 'Accents', items: [
+    { key: 'accent',           label: 'Accent (blue)',      default: '#6EA8FE' },
+    { key: 'accentSecondary',  label: 'Accent 2 (indigo)',  default: '#4C6EF5' },
+    { key: 'amber',            label: 'Amber / light',      default: '#FFC24B' },
+  ]},
+  { group: 'Status', items: [
+    { key: 'danger',           label: 'Danger / off',       default: '#E06767' },
+    { key: 'success',          label: 'Success / on',       default: '#4CAF50' },
+  ]},
+];
+
+// All token keys flattened (used for defaults / normalization).
+const THEME_KEYS = THEME_TOKENS.flatMap(g => g.items.map(t => t.key));
+
+// Returns dashboardData.theme, backfilled with defaults for any missing token
+// so renderers can always read a value.
+function themeValues() {
+  const t = dashboardData.theme || {};
+  const out = {};
+  THEME_TOKENS.forEach(g => g.items.forEach(tok => {
+    out[tok.key] = t[tok.key] || tok.default;
+  }));
+  return out;
+}
+
+// Builds the Theme & Colors form (swatch + hex text field per token) into
+// #themeBox. Called once from initEditor(); inputs persist across re-renders
+// of the preview (only the preview re-renders, not this form).
+function renderThemeForm() {
+  const box = document.getElementById('themeBox');
+  if (!box) return;
+  const vals = themeValues();
+  let html = '';
+  html += `<div class="hint" style="margin-bottom:10px">Colors used across every card and the dashboard shell. Defaults match the built-in look — change any to customize. The preview updates live.</div>`;
+  THEME_TOKENS.forEach(group => {
+    html += `<div class="theme-group-label">${group.group}</div>`;
+    group.items.forEach(tok => {
+      const v = vals[tok.key];
+      const isDefault = v.toLowerCase() === tok.default.toLowerCase();
+      html += `
+        <div class="theme-row">
+          <input type="color" class="theme-swatch" id="themeSwatch_${tok.key}" value="${v}" onchange="onThemeInput('${tok.key}', this.value)" oninput="onThemeInput('${tok.key}', this.value, true)">
+          <input type="text" class="theme-hex" id="themeHex_${tok.key}" value="${v}" placeholder="${tok.default}" onchange="onThemeHexInput('${tok.key}', this.value)" oninput="onThemeHexInput('${tok.key}', this.value, true)">
+          <label class="theme-token-label" for="themeHex_${tok.key}">${tok.label}</label>
+          <button type="button" class="theme-reset-btn${isDefault ? ' is-default' : ''}" title="Reset to default (${tok.default})" onclick="resetThemeToken('${tok.key}')">↺</button>
+        </div>`;
+    });
+  });
+  html += `<div class="btn-row" style="margin-top:10px"><button class="secondary" onclick="resetTheme()">Reset to defaults</button></div>`;
+  box.innerHTML = html;
+}
+
+// Swatch -> value (always #RRGGBB). `live` = during drag (input event): update
+// preview without re-rendering the whole preview (CSS vars only).
+function onThemeInput(key, value, live) {
+  const hexInput = document.getElementById('themeHex_' + key);
+  if (hexInput) hexInput.value = value;
+  dashboardData.theme = dashboardData.theme || {};
+  dashboardData.theme[key] = value;
+  updateResetBtnState(key, value);
+  applyThemeToPreview();
+  if (!live) updateJsonOutput();
+}
+
+// Hex text field -> normalize to #RRGGBB; keep the swatch in sync.
+function onThemeHexInput(key, value, live) {
+  let v = (value || '').trim();
+  if (!v) v = (dashboardData.theme || {})[key] || (THEME_TOKENS.flatMap(g => g.items).find(t => t.key === key) || {}).default || '#000000';
+  if (v[0] !== '#') v = '#' + v;
+  if (/^#[0-9A-Fa-f]{6}$/.test(v)) {
+    const swatch = document.getElementById('themeSwatch_' + key);
+    if (swatch) swatch.value = v;
+    dashboardData.theme = dashboardData.theme || {};
+    dashboardData.theme[key] = v;
+    updateResetBtnState(key, v);
+    applyThemeToPreview();
+    if (!live) updateJsonOutput();
+  }
+}
+
+// Toggles the dimmed "is-default" state on a token's ↺ button — gives a visual
+// cue that there's nothing to reset when the value already matches the default.
+function updateResetBtnState(key, value) {
+  const tok = THEME_TOKENS.flatMap(g => g.items).find(t => t.key === key);
+  if (!tok) return;
+  const btn = document.querySelector(`.theme-reset-btn[onclick="resetThemeToken('${key}')"]`);
+  if (!btn) return;
+  const isDefault = (value || '').toLowerCase() === tok.default.toLowerCase();
+  btn.classList.toggle('is-default', isDefault);
+}
+
+function resetTheme() {
+  dashboardData.theme = {};
+  THEME_TOKENS.forEach(g => g.items.forEach(tok => {
+    dashboardData.theme[tok.key] = tok.default;
+  }));
+  renderThemeForm();
+  applyThemeToPreview();
+  updateJsonOutput();
+}
+
+// Resets a single token to its built-in default and refreshes the swatch, hex
+// field, preview, and JSON. Called by the per-row ↺ button.
+function resetThemeToken(key) {
+  const tok = THEME_TOKENS.flatMap(g => g.items).find(t => t.key === key);
+  if (!tok) return;
+  dashboardData.theme = dashboardData.theme || {};
+  dashboardData.theme[key] = tok.default;
+  const swatch = document.getElementById('themeSwatch_' + key);
+  const hex = document.getElementById('themeHex_' + key);
+  if (swatch) swatch.value = tok.default;
+  if (hex) hex.value = tok.default;
+  const btn = document.querySelector(`.theme-reset-btn[onclick="resetThemeToken('${key}')"]`);
+  if (btn) btn.classList.add('is-default');
+  applyThemeToPreview();
+  updateJsonOutput();
+}
+
+// Sets CSS variables on every .remote-screen so the preview (in-frame and
+// expanded modal — same node, moved around) picks them up. Called on every
+// theme edit and after initEditor/renderPreview.
+function applyThemeToPreview() {
+  const vals = themeValues();
+  const screens = document.querySelectorAll('.remote-screen');
+  screens.forEach(el => {
+    Object.keys(vals).forEach(key => {
+      el.style.setProperty('--' + cssVarFor(key), vals[key]);
+    });
+  });
+}
+
+// Maps camelCase token keys to the CSS variable names used in styles.css.
+function cssVarFor(key) {
+  const map = {
+    background: 'bg',
+    cardSurface: 'card',
+    insetSurface: 'inset',
+    controlBackground: 'control',
+    primaryText: 'text',
+    mutedText: 'muted',
+    iconTint: 'icon',
+    accent: 'accent',
+    accentSecondary: 'accent2',
+    amber: 'amber',
+    danger: 'danger',
+    success: 'success',
+  };
+  return map[key] || key;
+}
+
+// ---- Reusable color picker field for card color overrides -------------------
+//
+// Same swatch + hex + ↺ reset control as the theme form, but for per-card
+// color options (scene_grid item `color`, switch `on_color`). These support
+// ARGB (#AARRGGBB) — the <input type="color"> swatch only handles #RRGGBB, so
+// it shows the RGB part and preserves the alpha prefix from the hex field
+// when the swatch changes. Reset clears to empty (= use the built-in default).
+
+// Returns the #RRGGBB portion of an ARGB/RGB hex string for the swatch.
+function rgbPartOf(hex) {
+  if (!hex) return '#000000';
+  let s = hex.trim().replace(/^#/, '');
+  if (s.length === 8) s = s.slice(2);      // AARRGGBB -> RRGGBB
+  if (s.length === 6) return '#' + s;
+  return '#000000';
+}
+
+// Returns the alpha prefix (e.g. "66") from an #AARRGGBB string, or '' if
+// opaque / no alpha.
+function alphaPartOf(hex) {
+  if (!hex) return '';
+  let s = hex.trim().replace(/^#/, '');
+  return s.length === 8 ? s.slice(0, 2) : '';
+}
+
+// Generates HTML for a color picker row. `id` is a base id (e.g. 'giColor');
+// the swatch gets id `${id}Swatch`, the hex field gets `${id}Hex`.
+// `currentValue` is the existing hex string (may be empty). `placeholder`
+// is the default hex shown in the hex field + swatch when empty (e.g.
+// "#66009688" — the built-in color used when the override is not set).
+function colorFieldHtml(id, currentValue, placeholder) {
+  const v = (currentValue || '').trim();
+  const def = (placeholder || '').trim();
+  // Swatch shows the configured color, or the default's RGB part when empty
+  // — so an unconfigured field reads as "the default", not black.
+  const swatchVal = v ? rgbPartOf(v) : (def ? rgbPartOf(def) : '#000000');
+  const isEmpty = !v;
+  return `
+    <div class="theme-row theme-row-card">
+      <input type="color" class="theme-swatch" id="${id}Swatch" value="${swatchVal}" onchange="onColorFieldInput('${id}', this.value, '${def}')" oninput="onColorFieldInput('${id}', this.value, '${def}', true)">
+      <input type="text" class="theme-hex" id="${id}Hex" value="${v}" placeholder="${def}" onchange="onColorFieldHexInput('${id}', this.value, '${def}')" oninput="onColorFieldHexInput('${id}', this.value, '${def}', true)">
+      <button type="button" class="theme-reset-btn${isEmpty ? ' is-default' : ''}" id="${id}Reset" title="Reset to default" onclick="resetColorField('${id}', '${def}')">↺</button>
+    </div>`;
+}
+
+// Swatch changed -> preserve alpha from the hex field, update hex field.
+function onColorFieldInput(id, value, def, live) {
+  const hexInput = document.getElementById(id + 'Hex');
+  const existing = hexInput ? hexInput.value.trim() : '';
+  const alpha = alphaPartOf(existing) || alphaPartOf(def);
+  const newHex = '#' + (alpha ? alpha : '') + value.replace(/^#/, '').toLowerCase();
+  if (hexInput) hexInput.value = newHex;
+  updateColorFieldResetBtn(id, newHex);
+  if (!live) renderPreview();
+}
+
+// Hex text field changed -> update swatch to match (if valid). When cleared,
+// the swatch reverts to the default color (not black).
+function onColorFieldHexInput(id, value, def, live) {
+  let v = (value || '').trim();
+  if (v && v[0] !== '#') v = '#' + v;
+  if (!v || /^#[0-9A-Fa-f]{6}$/.test(v) || /^#[0-9A-Fa-f]{8}$/.test(v)) {
+    const swatch = document.getElementById(id + 'Swatch');
+    if (swatch) swatch.value = v ? rgbPartOf(v) : (def ? rgbPartOf(def) : '#000000');
+    updateColorFieldResetBtn(id, v);
+    if (!live) renderPreview();
+  }
+}
+
+// Reset button -> clear the field (empty = use built-in default). Swatch
+// reverts to the default color so it doesn't read as black.
+function resetColorField(id, def) {
+  const hexInput = document.getElementById(id + 'Hex');
+  const swatch = document.getElementById(id + 'Swatch');
+  if (hexInput) hexInput.value = '';
+  if (swatch) swatch.value = def ? rgbPartOf(def) : '#000000';
+  const btn = document.getElementById(id + 'Reset');
+  if (btn) btn.classList.add('is-default');
+  renderPreview();
+}
+
+// Toggles the dimmed "is-default" state on a card color field's ↺ button.
+function updateColorFieldResetBtn(id, value) {
+  const btn = document.getElementById(id + 'Reset');
+  if (!btn) return;
+  btn.classList.toggle('is-default', !value);
+}
+
+// Reads the current value of a card color field (the hex text field).
+function colorFieldValue(id) {
+  const el = document.getElementById(id + 'Hex');
+  return el ? el.value.trim() : '';
+}
+
+// Sets the value of a card color field (updates both swatch and hex). When
+// the value is empty, the swatch reverts to the default color (not black).
+function setColorFieldValue(id, value) {
+  const v = (value || '').trim();
+  const hexInput = document.getElementById(id + 'Hex');
+  const swatch = document.getElementById(id + 'Swatch');
+  if (hexInput) hexInput.value = v;
+  // Read the default from the placeholder so the swatch shows the right color.
+  const def = hexInput ? (hexInput.placeholder || '').trim() : '';
+  if (swatch) swatch.value = v ? rgbPartOf(v) : (def ? rgbPartOf(def) : '#000000');
+  updateColorFieldResetBtn(id, v);
+}
+

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -156,7 +156,7 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   .remote-screen {
     width: 164px; height: 272px;
     overflow: hidden; border-radius: 4px;
-    background: #0d0f14; border: 1px solid #050608;
+    background: var(--bg); border: 1px solid #050608;
     cursor: zoom-in;
     display: flex; flex-direction: column;
   }
@@ -358,12 +358,12 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
     display: none;
   }
 
-  .preview-apple-remote, .preview-tv-remote { background: #161616; border-radius: 24px; padding: 20px; display: flex; flex-direction: column; align-items: center; gap: 18px; max-width: 260px; margin: 0 auto; }
-  .preview-trackpad { width: 160px; height: 160px; background: #232323; border-radius: 50%; position: relative; display: flex; align-items: center; justify-content: center; }
-  .preview-inner-select { width: 46px; height: 46px; background: #303030; border-radius: 50%; }
+  .preview-apple-remote, .preview-tv-remote { background: var(--card); border-radius: 24px; padding: 20px; display: flex; flex-direction: column; align-items: center; gap: 18px; max-width: 260px; margin: 0 auto; }
+  .preview-trackpad { width: 160px; height: 160px; background: var(--control); border-radius: 50%; position: relative; display: flex; align-items: center; justify-content: center; }
+  .preview-inner-select { width: 46px; height: 46px; background: var(--control); border-radius: 50%; opacity: 0.7; }
   .preview-row-buttons { display: flex; justify-content: space-around; width: 100%; gap: 10px; }
-  .preview-pill { background: #2a2a2a; border-radius: 50px; padding: 8px 16px; font-size: 12px; color: #e6e6e6; }
-  .preview-play-btn { width: 44px; height: 44px; background: #2a2a2a; border-radius: 50%; display: flex; align-items: center; justify-content: center; color: #e6e6e6; }
+  .preview-pill { background: var(--control); border-radius: 50px; padding: 8px 16px; font-size: 12px; color: var(--text); }
+  .preview-play-btn { width: 44px; height: 44px; background: var(--control); border-radius: 50%; display: flex; align-items: center; justify-content: center; color: var(--text); }
   .preview-grid { display: grid; gap: 8px; min-width: 0; }
   .preview-tile { background: #2a2a2a; border-radius: 8px; padding: 10px; font-size: 0.82rem; text-align: center; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; box-sizing: border-box; }
 
@@ -386,38 +386,38 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   }
   .preview-scene-tile.no-icon .st-label { font-size: 15px; margin-top: 0; }
   .preview-button-tile .bt-label {
-    color: #E6F0F1; font-size: 12px; font-weight: 500; text-align: center; max-width: 100%;
+    color: var(--text); font-size: 12px; font-weight: 500; text-align: center; max-width: 100%;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
   }
-  .preview-button-tile.no-icon { background: #2A4954; }
-  .preview-button-tile.has-icon { background: #2A4954; }
+  .preview-button-tile.no-icon { background: var(--control); }
+  .preview-button-tile.has-icon { background: var(--control); }
   .preview-button-tile.no-icon .bt-label { font-size: 15px; }
 
   /* cover card — mirrors CoverCard.kt's 3 layouts (default / horizontal / vertical)[cite: 1] */
-  .preview-cover { border-radius: 18px; background: #1E3841; padding: 12px 14px; box-sizing: border-box; }
+  .preview-cover { border-radius: 18px; background: var(--card); padding: 12px 14px; box-sizing: border-box; }
   .preview-cover.layout-horizontal { display: flex; align-items: center; gap: 12px; }
   .preview-cover.layout-default { display: flex; flex-direction: column; gap: 12px; }
   .preview-cover.layout-vertical { display: flex; flex-direction: column; align-items: center; gap: 8px; }
-  .pc-icon { width: 42px; height: 42px; border-radius: 12px; background: #2A4954; display: flex; align-items: center; justify-content: center; flex: 0 0 auto; }
+  .pc-icon { width: 42px; height: 42px; border-radius: 12px; background: var(--control); display: flex; align-items: center; justify-content: center; flex: 0 0 auto; }
   .pc-icon.pc-icon-lg { width: 48px; height: 48px; }
-  .pc-icon svg { width: 24px; height: 24px; fill: #B6C9CE; }
+  .pc-icon svg { width: 24px; height: 24px; fill: var(--icon); }
   .pc-namestate { display: flex; flex-direction: column; min-width: 0; }
   .pc-namestate.pc-center { align-items: center; text-align: center; }
-  .pc-name { color: #E6F0F1; font-size: 16px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
-  .pc-state { color: #93AFB6; font-size: 13px; }
+  .pc-name { color: var(--text); font-size: 16px; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+  .pc-state { color: var(--muted); font-size: 13px; }
   .pc-controls { display: flex; gap: 8px; }
   .pc-controls.pc-full { width: 100%; justify-content: space-evenly; }
-  .pc-btn { width: 44px; height: 44px; border-radius: 50%; background: #2C4C58; display: flex; align-items: center; justify-content: center; flex: 0 0 auto; }
-  .pc-btn svg { width: 24px; height: 24px; fill: #CBDCE0; }
+  .pc-btn { width: 44px; height: 44px; border-radius: 50%; background: var(--control); display: flex; align-items: center; justify-content: center; flex: 0 0 auto; }
+  .pc-btn svg { width: 24px; height: 24px; fill: var(--icon); }
   .pc-btn.pc-disabled { opacity: 0.35; }
   /* Mushroom-style draggable slider (position/tilt/brightness) — mirrors CoverCard.kt's
      and LightCard.kt's PercentSlider composable, static (non-interactive) in this preview.[cite: 1] */
-  .pc-slider { position: relative; width: 100%; height: 36px; border-radius: 18px; background: #152B33; overflow: hidden; box-sizing: border-box; display: flex; align-items: center; justify-content: center; }
+  .pc-slider { position: relative; width: 100%; height: 36px; border-radius: 18px; background: var(--inset); overflow: hidden; box-sizing: border-box; display: flex; align-items: center; justify-content: center; }
   .pc-slider-fill { position: absolute; left: 0; top: 0; bottom: 0; border-radius: 18px; }
-  .pc-slider-label { position: relative; color: #E6F0F1; font-size: 13px; font-weight: 600; z-index: 1; }
-  .pc-cycle-btn { width: 36px; height: 36px; border-radius: 50%; background: #2C4C58; display: flex; align-items: center; justify-content: center; flex: 0 0 auto; cursor: help; }
-  .pc-cycle-btn svg { width: 22px; height: 22px; fill: #CBDCE0; }
-  .preview-light { border-radius: 18px; background: #1E3841; padding: 12px 14px; box-sizing: border-box; }
+  .pc-slider-label { position: relative; color: var(--text); font-size: 13px; font-weight: 600; z-index: 1; }
+  .pc-cycle-btn { width: 36px; height: 36px; border-radius: 50%; background: var(--control); display: flex; align-items: center; justify-content: center; flex: 0 0 auto; cursor: help; }
+  .pc-cycle-btn svg { width: 22px; height: 22px; fill: var(--icon); }
+  .preview-light { border-radius: 18px; background: var(--card); padding: 12px 14px; box-sizing: border-box; }
   .preview-light.layout-horizontal { display: flex; align-items: center; gap: 12px; }
   .preview-light.layout-default { display: flex; flex-direction: column; gap: 10px; }
   .preview-light.layout-vertical { display: flex; flex-direction: column; align-items: center; gap: 8px; }
@@ -427,77 +427,114 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   .pl-swatch { width: 28px; height: 28px; border-radius: 50%; flex: 0 0 auto; box-shadow: 0 0 0 1px rgba(255,255,255,0.15) inset; }
 
   /* media_player card — mirrors MediaPlayerCard.kt's compact Mushroom-style tile[cite: 1] */
-  .preview-media { border-radius: 18px; background: #1E3841; padding: 12px 14px; box-sizing: border-box; display: flex; flex-direction: column; gap: 10px; }
+  .preview-media { border-radius: 18px; background: var(--card); padding: 12px 14px; box-sizing: border-box; display: flex; flex-direction: column; gap: 10px; }
   .pm-row { display: flex; align-items: center; gap: 12px; }
-  .pm-avatar { width: 42px; height: 42px; border-radius: 50%; background: #2A4954; display: flex; align-items: center; justify-content: center; flex: 0 0 auto; overflow: hidden; }
-  .pm-avatar svg { width: 22px; height: 22px; fill: #B6C9CE; }
+  .pm-avatar { width: 42px; height: 42px; border-radius: 50%; background: var(--control); display: flex; align-items: center; justify-content: center; flex: 0 0 auto; overflow: hidden; }
+  .pm-avatar svg { width: 22px; height: 22px; fill: var(--icon); }
   .pm-controls { display: flex; align-items: center; gap: 8px; }
-  .pm-btn { width: 36px; height: 36px; border-radius: 10px; background: #23414B; display: flex; align-items: center; justify-content: center; flex: 0 0 auto; }
-  .pm-btn.pm-accent { background: #4C6EF5; }
-  .pm-btn svg { width: 18px; height: 18px; fill: #E6F0F1; }
+  .pm-btn { width: 36px; height: 36px; border-radius: 10px; background: var(--control); display: flex; align-items: center; justify-content: center; flex: 0 0 auto; }
+  .pm-btn.pm-accent { background: var(--accent2); }
+  .pm-btn svg { width: 18px; height: 18px; fill: var(--text); }
   .pm-btn.pm-swap { margin-left: auto; }
-  .preview-media-full { border-radius: 20px; background: #1B343D; padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; align-items: center; gap: 14px; }
-  .pm-art { width: 100%; aspect-ratio: 1.2; border-radius: 16px; background: #3A2E5A; background-size: cover; background-position: center; display: flex; align-items: center; justify-content: center; }
+  .preview-media-full { border-radius: 20px; background: var(--card); padding: 16px; box-sizing: border-box; display: flex; flex-direction: column; align-items: center; gap: 14px; }
+  .pm-art { width: 100%; aspect-ratio: 1.2; border-radius: 16px; background: var(--control); background-size: cover; background-position: center; display: flex; align-items: center; justify-content: center; }
   .pm-art svg { width: 48px; height: 48px; fill: rgba(255,255,255,0.6); }
-  .pm-full-title { color: #F1F4FA; font-size: 20px; font-weight: 700; text-align: center; }
-  .pm-full-subtitle { color: #B6BECC; font-size: 14px; text-align: center; }
+  .pm-full-title { color: var(--text); font-size: 20px; font-weight: 700; text-align: center; }
+  .pm-full-subtitle { color: var(--muted); font-size: 14px; text-align: center; }
   .pm-progress { width: 100%; height: 4px; border-radius: 2px; background: rgba(255,255,255,0.2); overflow: hidden; }
-  .pm-progress-fill { height: 100%; background: #4C6EF5; }
+  .pm-progress-fill { height: 100%; background: var(--accent2); }
   .pm-full-controls { display: flex; justify-content: space-evenly; align-items: center; width: 100%; }
-  .pm-full-btn { width: 50px; height: 50px; border-radius: 50%; background: rgba(44,76,88,0.35); display: flex; align-items: center; justify-content: center; }
+  .pm-full-btn { width: 50px; height: 50px; border-radius: 50%; background: var(--control); display: flex; align-items: center; justify-content: center; opacity: 0.6; }
   .pm-full-btn.pm-big { width: 64px; height: 64px; }
-  .pm-full-btn.pm-accent { background: #4C6EF5; }
+  .pm-full-btn.pm-accent { background: var(--accent2); opacity: 1; }
   .pm-full-btn svg { width: 24px; height: 24px; fill: #fff; }
 
-  .preview-clock-weather { background: #1B343D; border-radius: 18px; padding: 12px; display: flex; align-items: center; gap: 12px; }
+  .preview-clock-weather { background: var(--card); border-radius: 18px; padding: 12px; display: flex; align-items: center; gap: 12px; }
   .preview-clock-weather .cw-emoji { font-size: 34px; }
-  .preview-clock-weather .cw-time { color: #F2F5FA; font-size: 26px; font-weight: 300; line-height: 1.1; }
-  .preview-clock-weather .cw-date { color: #9AB0C4; font-size: 12px; }
-  .preview-clock-weather .cw-right { text-align: right; color: #9AB0C4; font-size: 11px; }
-  .preview-clock-weather .cw-temp { color: #F2F5FA; font-size: 20px; font-weight: 600; }
+  .preview-clock-weather .cw-time { color: var(--text); font-size: 26px; font-weight: 300; line-height: 1.1; }
+  .preview-clock-weather .cw-date { color: var(--muted); font-size: 12px; }
+  .preview-clock-weather .cw-right { text-align: right; color: var(--muted); font-size: 11px; }
+  .preview-clock-weather .cw-temp { color: var(--text); font-size: 20px; font-weight: 600; }
   .preview-clock-weather-wrap { display: flex; flex-direction: column; gap: 8px; }
-  .cw-forecast-row { display: flex; align-items: center; gap: 8px; font-size: 12px; color: #9AB0C4; }
+  .cw-forecast-row { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--muted); }
   .cw-forecast-row .cw-fday { width: 34px; }
   .cw-forecast-row .cw-femoji { width: 22px; text-align: center; }
   .cw-forecast-row .cw-flow { width: 30px; text-align: right; }
-  .cw-forecast-row .cw-fhigh { width: 30px; text-align: right; color: #F2F5FA; font-weight: 600; }
-  .cw-forecast-row .cw-fbar { flex: 1; height: 6px; border-radius: 3px; background: #2C3E4E; position: relative; overflow: hidden; }
-  .cw-forecast-row .cw-fbar-fill { position: absolute; top: 0; bottom: 0; background: linear-gradient(90deg, #3DD68C, #9BE7C4); border-radius: 3px; }
+  .cw-forecast-row .cw-fhigh { width: 30px; text-align: right; color: var(--text); font-weight: 600; }
+  .cw-forecast-row .cw-fbar { flex: 1; height: 6px; border-radius: 3px; background: var(--control); position: relative; overflow: hidden; }
+  .cw-forecast-row .cw-fbar-fill { position: absolute; top: 0; bottom: 0; background: linear-gradient(90deg, var(--success), var(--amber)); border-radius: 3px; }
 
-  .preview-vacuum { background: #1B343D; border-radius: 20px; padding: 14px; }
-  .preview-vacuum .vc-header { display: flex; align-items: center; justify-content: space-between; font-size: 13px; color: #93AFB6; }
-  .preview-vacuum .vc-name { color: #E6F0F1; font-size: 16px; font-weight: 600; }
+  .preview-vacuum { background: var(--card); border-radius: 20px; padding: 14px; }
+  .preview-vacuum .vc-header { display: flex; align-items: center; justify-content: space-between; font-size: 13px; color: var(--muted); }
+  .preview-vacuum .vc-name { color: var(--text); font-size: 16px; font-weight: 600; }
   .preview-vacuum .vc-rooms { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
-  .preview-vacuum .vc-room { background: #2A4954; color: #E6F0F1; border-radius: 10px; padding: 6px 10px; font-size: 12px; }
+  .preview-vacuum .vc-room { background: var(--control); color: var(--text); border-radius: 10px; padding: 6px 10px; font-size: 12px; }
 
-  .preview-climate { background: #1B343D; border-radius: 16px; padding: 12px; color: #E6F0F1; }
+  .preview-climate { background: var(--card); border-radius: 16px; padding: 12px; color: var(--text); }
   .preview-climate .cc-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
   .preview-climate .cc-name { font-size: 14px; font-weight: 600; }
-  .preview-climate .cc-power { width: 26px; height: 26px; border-radius: 50%; background: #1E3A2E; color: #9BE7C4; display: flex; align-items: center; justify-content: center; }
-  .preview-climate .cc-power.is-off { background: #3A2E2E; color: #E06767; }
+  .preview-climate .cc-power { width: 26px; height: 26px; border-radius: 50%; background: var(--success); color: #fff; display: flex; align-items: center; justify-content: center; }
+  .preview-climate .cc-power.is-off { background: var(--danger); color: #fff; }
   .preview-climate .cc-temp-row { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
-  .preview-climate .cc-stepper { width: 34px; height: 34px; border-radius: 50%; background: #2C4C58; display: flex; align-items: center; justify-content: center; color: #CBDCE0; font-size: 18px; flex-shrink: 0; }
+  .preview-climate .cc-stepper { width: 34px; height: 34px; border-radius: 50%; background: var(--control); display: flex; align-items: center; justify-content: center; color: var(--icon); font-size: 18px; flex-shrink: 0; }
   .preview-climate .cc-temp-col { text-align: center; }
   .preview-climate .cc-temp { font-size: 26px; font-weight: 700; }
-  .preview-climate .cc-current { font-size: 11px; color: #93AFB6; }
-  .preview-climate .cc-caption { font-size: 10px; color: #6D8891; font-weight: 600; margin: 6px 0 3px; }
+  .preview-climate .cc-temp-range { font-size: 22px; }
+  .preview-climate .cc-current { font-size: 11px; color: var(--muted); }
+  .preview-climate .cc-caption { font-size: 10px; color: var(--muted); font-weight: 600; margin: 6px 0 3px; }
   .preview-climate .cc-row { display: flex; gap: 5px; margin-bottom: 5px; }
-  .preview-climate .cc-chip { flex: 1; height: 28px; border-radius: 8px; background: #23414B; color: #93AFB6; display: flex; align-items: center; justify-content: center; font-size: 11px; }
-  .preview-climate .cc-chip-selected { background: #4C6EF5; color: #fff; }
+  .preview-climate .cc-chip { flex: 1; height: 28px; border-radius: 8px; background: var(--control); color: var(--muted); display: flex; align-items: center; justify-content: center; font-size: 11px; }
+  .preview-climate .cc-chip-selected { background: var(--accent2); color: #fff; }
   .preview-climate .cc-chip svg { width: 16px; height: 16px; }
 
-  .preview-fan { background: #1B343D; border-radius: 16px; padding: 12px; color: #E6F0F1; }
+  .preview-fan { background: var(--card); border-radius: 16px; padding: 12px; color: var(--text); }
   .preview-fan .fx-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
   .preview-fan .fx-name { font-size: 14px; font-weight: 600; }
-  .preview-fan .fx-power { width: 26px; height: 26px; border-radius: 50%; background: #1E3A2E; color: #9BE7C4; display: flex; align-items: center; justify-content: center; font-size: 13px; }
-  .preview-fan .fx-power.is-off { background: #3A2E2E; color: #E06767; }
-  .preview-fan .fx-caption { font-size: 10px; color: #6D8891; font-weight: 600; margin: 6px 0 3px; }
+  .preview-fan .fx-power { width: 26px; height: 26px; border-radius: 50%; background: var(--success); color: #fff; display: flex; align-items: center; justify-content: center; font-size: 13px; }
+  .preview-fan .fx-power.is-off { background: var(--danger); color: #fff; }
+  .preview-fan .fx-caption { font-size: 10px; color: var(--muted); font-weight: 600; margin: 6px 0 3px; }
   .preview-fan .fx-row { display: flex; gap: 5px; margin-bottom: 5px; }
-  .preview-fan .fx-chip { flex: 1; height: 28px; border-radius: 8px; background: #23414B; color: #93AFB6; display: flex; align-items: center; justify-content: center; font-size: 11px; }
-  .preview-fan .fx-chip-selected { background: #4C6EF5; color: #fff; }
+  .preview-fan .fx-chip { flex: 1; height: 28px; border-radius: 8px; background: var(--control); color: var(--muted); display: flex; align-items: center; justify-content: center; font-size: 11px; }
+  .preview-fan .fx-chip-selected { background: var(--accent2); color: #fff; }
   .preview-fan .fx-pct-row { display: flex; align-items: center; justify-content: space-between; }
-  .preview-fan .fx-pct-btn { width: 30px; height: 30px; border-radius: 50%; background: #2C4C58; display: flex; align-items: center; justify-content: center; color: #CBDCE0; }
+  .preview-fan .fx-pct-btn { width: 30px; height: 30px; border-radius: 50%; background: var(--control); display: flex; align-items: center; justify-content: center; color: var(--icon); }
   .preview-fan .fx-pct { font-size: 16px; font-weight: 600; }
-  .preview-fan-simple { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-radius: 18px; background: #2B3A67; }
+  .preview-fan-simple { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-radius: 18px; background: var(--control); }
   .preview-fan-simple .fs-name { font-size: 15px; font-weight: 600; }
-  .preview-fan-simple .fs-state { font-size: 12px; color: #93AFB6; }
+  .preview-fan-simple .fs-state { font-size: 12px; color: var(--muted); }
+
+  /* Entity autocomplete dropdown — attached to Entity ID inputs in the card
+     edit form by attachEntityAutocomplete() in preview.js. Floats below the
+     input, same width, dark theme to match the editor. */
+  .ea-dropdown { position: fixed; z-index: 9999; background: #2d2d2d; border: 1px solid #444; border-radius: 6px; max-height: 260px; overflow-y: auto; box-shadow: 0 6px 18px rgba(0,0,0,0.5); }
+  .ea-item { display: flex; justify-content: space-between; align-items: center; padding: 6px 10px; cursor: pointer; font-size: 0.82rem; gap: 8px; }
+  .ea-item:hover { background: #383838; }
+  .ea-item.ea-selected { background: #00E5FF; color: #121212; }
+  .ea-item.ea-selected .ea-name { color: #333; }
+  .ea-id { font-family: monospace; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .ea-name { color: #888; font-size: 0.78rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex-shrink: 0; max-width: 45%; }
+  .ea-more { padding: 4px 10px; font-size: 0.75rem; color: #666; font-style: italic; }
+
+  /* ---- Theme & Colors form ---- */
+  .theme-group-label { font-size: 0.72rem; font-weight: 700; color: #00E5FF; text-transform: uppercase; letter-spacing: 0.5px; margin: 12px 0 4px; }
+  .theme-group-label:first-child { margin-top: 0; }
+  .theme-row { display: flex; align-items: center; gap: 8px; margin: 5px 0; }
+  .theme-swatch { width: 34px !important; height: 34px; min-width: 34px; padding: 2px; border: 1px solid #444; border-radius: 6px; background: #2d2d2d; cursor: pointer; flex: 0 0 auto; }
+  .theme-hex { width: 90px; flex: 0 0 auto; font-family: monospace; text-transform: uppercase; }
+  .theme-token-label { margin: 0; font-size: 0.8rem; color: #ccc; flex: 1; min-width: 0; }
+  .theme-reset-btn { flex: 0 0 auto; width: 28px; height: 28px; min-width: 28px; padding: 0; margin: 0; background: #2d2d2d; color: #aaa; border: 1px solid #444; border-radius: 6px; font-size: 1rem; line-height: 1; cursor: pointer; display: flex; align-items: center; justify-content: center; }
+  .theme-reset-btn:hover { background: #383838; color: #fff; }
+  .theme-reset-btn.is-default { opacity: 0.3; cursor: default; }
+  .theme-reset-btn.is-default:hover { background: #2d2d2d; color: #aaa; }
+  /* Card editor variant: no label, so the hex field flexes to fill width. */
+  .theme-row-card .theme-hex { flex: 1 1 auto; width: auto; }
+
+  /* ---- Theme CSS variables (preview surface) ----
+     Defaults match the app's compiled-in ThemeConfig. Overridden at runtime
+     by applyThemeToPreview() in theme.js, which sets these on .remote-screen. */
+  .remote-screen {
+    --bg: #0E2229; --card: #1B343D; --inset: #152B33; --control: #2C4C58;
+    --text: #E6F0F1; --muted: #93AFB6; --icon: #CBDCE0;
+    --accent: #6EA8FE; --accent2: #4C6EF5; --amber: #FFC24B;
+    --danger: #E06767; --success: #4CAF50;
+  }


### PR DESCRIPTION
Replaces ~250 hardcoded `Color(0x...)` literals across ~25 Kotlin files with 12 semantic theme tokens (`background`, `cardSurface`, `insetSurface`, `controlBackground`, `primaryText`, `mutedText`, `iconTint`, `accent`, `accentSecondary`, `amber`, `danger`, `success`). Tokens default to the original palette, so an empty `theme` block renders identically to before.

## Editor (`docs/` + bundled mirror)
- New **"Theme & Colors"** left-pane section (sits at #4, after upstream's new "Activities" #3): swatch + hex field + per-token reset (↺) for each of the 12 tokens, live preview via CSS variables on `.remote-screen`
- `SwitchCard.on_color` and `SceneGridCard` per-scene color override fields now use the same swatch + hex + reset control (ARGB-aware — swatch shows the RGB part, preserves the alpha prefix)
- `theme` whitelisted on both editor load paths (import + device) so it survives round-trips

## Kotlin
- `ThemeConfig` data class (12 hex-string fields) parsed from the `theme` block in `DashboardLoader` (safe on old configs via `ignoreUnknownKeys`)
- New `ui/Theme.kt`: `ThemeColors`, `parseHexColor`, `LocalTheme` CompositionLocal, `ProvideTheme`
- `Dashboard` wraps content in `ProvideTheme`; `CardContext` gains a `theme` field read by all card impls + dialogs
- Shell UI (`Dashboard`, `SettingsMenu`, `Topstatusbar`) reads `LocalTheme.current`
- Upstream's new **Activities overlay** and **TitleCard** also themed for consistency (9 + 2 hardcoded colors converted)
- Existing config-driven paths (`SwitchCard.on_color`, `SceneGridCard` per-scene color, `LightCard.rgb_color`) left intact — they override the theme

## Config example
```json
{
  "theme": {
    "background": "#0E2229",
    "cardSurface": "#1B343D",
    "accent": "#6EA8FE",
    "primaryText": "#E6F0F1"
  }
}
```
Any omitted token falls back to its default, so partial themes work.

## Notes / scope
Self-contained against `main`. Adapted to upstream's 0.8.0 changes:
- Kept upstream's `irDevices`/`activities`/`ActivityConfig`/`IrDeviceConfig` model; the original commit's older `irActivities` shape was dropped (superseded by upstream's richer Activities engine)
- Kept upstream's hierarchical `PageIndicator` (parent/child page dots) — applied theme tokens to its colors rather than reverting to the old flat layout
- `CameraCard.kt` is not touched here (it's in a separate PR); the original commit's theming of that file was dropped to keep this PR scoped

Built and verified on a HA100 (Android 8.1, MT6580).
