### PR TITLE
feat(web): live HA entity data in the dashboard editor preview

### DIFF
--- a/app/src/main/assets/docs/js/cards.js
+++ b/app/src/main/assets/docs/js/cards.js
@@ -289,6 +289,26 @@ function updateCardFormInputs() {
       <div class="hint">This card type isn't fully modeled in the builder yet — paste the options object directly.</div>
     `;
   }
+
+  // Attach live entity autocomplete to whichever entity_id fields this card
+  // type created. Only attaches when /ha-states data is available (device mode
+  // + HA connected); otherwise the inputs stay plain text fields.
+  const mainDomain = type === 'clock_weather' ? 'weather'
+    : type === 'source_select' ? null
+    : type;
+  ['optEntityId', 'optRemoteEntity', 'optMediaEntity', 'optMuteEntity',
+    'optCalendarEntity', 'optMapImage', 'giEntityId'].forEach(id => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const dom = id === 'optEntityId' ? mainDomain
+      : id === 'optRemoteEntity' ? 'remote'
+      : id === 'optMediaEntity' ? 'media_player'
+      : id === 'optMuteEntity' ? 'media_player'
+      : id === 'optCalendarEntity' ? 'calendar'
+      : id === 'optMapImage' ? 'image'
+      : null; // giEntityId — any domain (scene.*, script.*, media_player.*, …)
+    attachEntityAutocomplete(el, dom);
+  });
 }
 
 // media_player card: top_buttons only make sense on the "full" variant

--- a/app/src/main/assets/docs/js/cards.js
+++ b/app/src/main/assets/docs/js/cards.js
@@ -295,6 +295,7 @@ function updateCardFormInputs() {
   // + HA connected); otherwise the inputs stay plain text fields.
   const mainDomain = type === 'clock_weather' ? 'weather'
     : type === 'source_select' ? null
+    : type === 'select' ? ['select', 'input_select']
     : type;
   ['optEntityId', 'optRemoteEntity', 'optMediaEntity', 'optMuteEntity',
     'optCalendarEntity', 'optMapImage', 'giEntityId'].forEach(id => {

--- a/app/src/main/assets/docs/js/device.js
+++ b/app/src/main/assets/docs/js/device.js
@@ -26,17 +26,44 @@ async function loadDashboardFromDevice() {
   try {
     const res = await fetch('/dashboard.json');
     deviceModeAvailable = true; // reaching this line at all means the app answered — even a 404 (no dashboard.json saved yet) still confirms device mode
+    await loadHaStates(); // best-effort: lets the preview render with live HA data instead of the static mocks
     if (res.ok) {
       const parsed = await res.json();
       applyParsedDashboard(parsed);
       initEditor();
       console.log('Loaded dashboard.json from this device.');
+    } else {
+      // No dashboard.json yet — the inline initEditor() already ran with the
+      // default empty page; just refresh the preview now that haStates is loaded.
+      renderPreview();
     }
   } catch (e) {
     deviceModeAvailable = false;
     console.log('Not served by the app (or offline) — using the paste/download flow instead.', e);
   }
   updateDeviceModeUi();
+}
+
+/**
+ * Fetches a snapshot of every HA entity the device currently knows, exposed
+ * by the app at /ha-states. Sets the global `haStates` (declared in preview.js)
+ * so the card renderers can use live state/names/attributes instead of the
+ * static *_MOCK examples. Failures are swallowed: on GitHub Pages or when HA
+ * is unreachable, haStates stays null and the preview quietly falls back to
+ * the mocks + prettyEntityName().
+ */
+async function loadHaStates() {
+  try {
+    const res = await fetch('/ha-states');
+    if (!res.ok) return;
+    const data = await res.json();
+    haStates = (data && data.states) ? data.states : null;
+    if (data && data.connected === false) {
+      console.log('HA not connected — preview will use example data.');
+    }
+  } catch (e) {
+    haStates = null; // not device mode, or older app build without the endpoint
+  }
 }
 
 /** Normalizes a parsed dashboard.json into dashboardData — same shape importJson() builds,

--- a/app/src/main/assets/docs/js/mocks.js
+++ b/app/src/main/assets/docs/js/mocks.js
@@ -41,6 +41,42 @@ const MDI = {
 };
 function mdiSvg(path) { return `<svg viewBox="0 0 24 24" fill="currentColor"><path d="${path}"/></svg>`; }
 
+// Mimics Home Assistant's default friendly_name generation: strip the domain
+// prefix, replace underscores with spaces, and title-case each word. Used by
+// the preview as a stand-in for the live friendly_name the app fetches from HA
+// (which the static editor page can't reach).
+function prettyEntityName(entityId) {
+  if (!entityId || typeof entityId !== 'string') return null;
+  const tail = entityId.includes('.') ? entityId.slice(entityId.indexOf('.') + 1) : entityId;
+  return tail.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+// Builds a per-card "mock" object for the preview that's live where possible:
+// starts from the static `baseMock` (so every field a renderer expects still
+// exists), then overlays the matching HA entity's real `state`, `friendly_name`
+// and `attributes` (which use the same HA attribute keys — brightness,
+// current_position, hvac_mode, supported_features, … — the renderers already
+// read off the mock). Returns `baseMock` unchanged when there's no live entity
+// for `entityId` (no HA connection, unknown entity, or not device mode), so
+// every renderer falls back to the example data it always showed.
+function liveMock(entityId, baseMock) {
+  const e = (typeof haEntity === 'function') ? haEntity(entityId) : null;
+  if (!e) return baseMock;
+  // Merge attributes over the mock, but skip null values — HA sends null for
+  // attributes a climate/cover/etc. doesn't currently have (e.g. temperature
+  // on a heat_cool thermostat with no setpoint), and those shouldn't clobber
+  // the mock's sane defaults (otherwise the preview renders "null°").
+  const merged = Object.assign({}, baseMock);
+  if (e.attributes) {
+    for (const k in e.attributes) {
+      if (e.attributes[k] != null) merged[k] = e.attributes[k];
+    }
+  }
+  merged.state = e.state;
+  merged.friendly_name = e.friendly_name || baseMock.friendly_name;
+  return merged;
+}
+
 function climateHvacIcon(m) {
   if (m === 'heat') return MDI.fire;
   if (m === 'cool') return MDI.snowflake;

--- a/app/src/main/assets/docs/js/preview.js
+++ b/app/src/main/assets/docs/js/preview.js
@@ -50,14 +50,16 @@ function haAttrStr(entityId, key) {
 //
 // `domain` filters candidates to entity_ids starting with "<domain>." — pass
 // null to offer every entity (used by scene_grid/button_grid where the entity
-// can be scene.*, script.*, media_player.*, …).
+// can be scene.*, script.*, media_player.*, …). Pass an array of strings to
+// match multiple domains (e.g. ['select', 'input_select'] for the select card).
 
 function attachEntityAutocomplete(inputEl, domain) {
   if (!inputEl || !haStates) return;
 
-  const prefix = domain ? domain + '.' : '';
+  const domains = Array.isArray(domain) ? domain : (domain ? [domain] : null);
+  const prefixes = domains ? domains.map(d => d + '.') : null;
   const items = Object.keys(haStates)
-    .filter(id => !prefix || id.startsWith(prefix))
+    .filter(id => !prefixes || prefixes.some(p => id.startsWith(p)))
     .map(id => ({
       id,
       name: haStates[id].friendly_name || id,

--- a/app/src/main/assets/docs/js/preview.js
+++ b/app/src/main/assets/docs/js/preview.js
@@ -1,5 +1,210 @@
 // ---- Preview ----------------------------------------------------------------
 
+// Live HA entity states, populated by loadHaStates() in device.js when the
+// editor is served by the app (http://<device-ip>:8080/builder/). null until
+// the fetch completes (or fails / not device mode) — renderers fall back to
+// the static *_MOCK examples then. Shape: { entity_id: { state, friendly_name,
+// attributes: {...} } }.
+let haStates = null;
+
+// Returns the live EntityState object for an entity_id, or null when no live
+// data is available (no HA connection, unknown entity, or not device mode).
+function haEntity(entityId) {
+  if (!entityId || !haStates) return null;
+  return haStates[entityId] || null;
+}
+
+// Live friendly_name for an entity, falling back to prettyEntityName() when we
+// have the entity but HA didn't send a friendly_name. null when no live data.
+function haFriendlyName(entityId) {
+  const e = haEntity(entityId);
+  if (!e) return null;
+  return e.friendly_name || prettyEntityName(entityId);
+}
+
+// Numeric attribute helper for live entities (mirrors HaModels.attrDouble).
+function haAttrNum(entityId, key) {
+  const e = haEntity(entityId);
+  if (!e || !e.attributes) return null;
+  const v = e.attributes[key];
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+// String attribute helper for live entities.
+function haAttrStr(entityId, key) {
+  const e = haEntity(entityId);
+  if (!e || !e.attributes) return null;
+  const v = e.attributes[key];
+  return v == null ? null : String(v);
+}
+
+// ---- Entity ID autocomplete for the card edit form --------------------------
+//
+// Attaches a custom dropdown to an <input> that lists matching HA entities
+// (filtered by domain) from the live /ha-states data. The user types to
+// narrow the list, clicks (or arrow-keys + Enter) to accept. Falls back to a
+// plain text input when haStates is null (no HA connection, or the editor is
+// opened from GitHub Pages instead of the device's own /builder/).
+//
+// `domain` filters candidates to entity_ids starting with "<domain>." — pass
+// null to offer every entity (used by scene_grid/button_grid where the entity
+// can be scene.*, script.*, media_player.*, …).
+
+function attachEntityAutocomplete(inputEl, domain) {
+  if (!inputEl || !haStates) return;
+
+  const prefix = domain ? domain + '.' : '';
+  const items = Object.keys(haStates)
+    .filter(id => !prefix || id.startsWith(prefix))
+    .map(id => ({
+      id,
+      name: haStates[id].friendly_name || id,
+      lower: id.toLowerCase(),
+      nameLower: (haStates[id].friendly_name || id).toLowerCase(),
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  let debounceTimer = null;
+  let suppressOpen = false; // set by accept() so the input event it dispatches doesn't immediately reopen
+
+  // Singleton: only one dropdown exists at a time across all inputs. Closing
+  // the previous (if any) on open prevents stray invisible dropdowns from
+  // accumulating when focus moves between fields.
+  if (!_eaState.globalListenersAttached) {
+    _eaState.globalListenersAttached = true;
+    // Capture phase so we also catch scrolls originating inside scrolling
+    // containers (the card-edit modal has its own internal scroll, which
+    // doesn't bubble to window).
+    document.addEventListener('scroll', () => {
+      if (_eaState.dropdown && _eaState.input) {
+        const r = _eaState.input.getBoundingClientRect();
+        if (r.bottom < 0 || r.top > window.innerHeight) _eaClose();
+ else _eaPosition();
+      }
+    }, { passive: true, capture: true });
+    window.addEventListener('resize', () => { if (_eaState.dropdown) _eaPosition(); });
+  }
+
+  function closeDropdown() { _eaClose(); }
+
+  function openDropdown(query) {
+    _eaClose();
+    const q = (query || '').toLowerCase();
+    const matches = q
+      ? items.filter(it => it.lower.includes(q) || it.nameLower.includes(q))
+      : items;
+    if (matches.length === 0) return;
+
+    const dd = document.createElement('div');
+    dd.className = 'ea-dropdown';
+
+    const maxShow = 60;
+    matches.slice(0, maxShow).forEach((it) => {
+      const row = document.createElement('div');
+      row.className = 'ea-item';
+      row.dataset.id = it.id;
+      row.innerHTML =
+        `<span class="ea-id">${it.id}</span>` +
+        `<span class="ea-name">${it.name}</span>`;
+      row.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        accept(it.id);
+      });
+      dd.appendChild(row);
+    });
+    if (matches.length > maxShow) {
+      const more = document.createElement('div');
+      more.className = 'ea-more';
+      more.textContent = (matches.length - maxShow) + ' more — keep typing to narrow';
+      dd.appendChild(more);
+    }
+
+    document.body.appendChild(dd);
+    _eaState.dropdown = dd;
+    _eaState.input = inputEl;
+    _eaState.selectedIdx = -1;
+    _eaPosition();
+  }
+
+  function accept(id) {
+    inputEl.value = id;
+    closeDropdown();
+    suppressOpen = true;
+    inputEl.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  inputEl.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    if (suppressOpen) { suppressOpen = false; return; }
+    debounceTimer = setTimeout(() => openDropdown(inputEl.value), 80);
+  });
+  inputEl.addEventListener('focus', () => openDropdown(inputEl.value));
+  inputEl.addEventListener('blur', () => setTimeout(() => {
+    // Only close if focus has actually left this input — clicking a dropdown
+    // item triggers a brief blur before mousedown, but preventDefault on the
+    // item's mousedown keeps focus here, so this blur closes only on a real
+    // focus shift to something else.
+    if (_eaState.input === inputEl) _eaClose();
+  }, 150));
+  inputEl.addEventListener('keydown', (e) => {
+    if (!_eaState.dropdown || _eaState.input !== inputEl) return;
+    if (e.key === 'Escape') { closeDropdown(); return; }
+    const opts = _eaState.dropdown.querySelectorAll('.ea-item');
+    if (opts.length === 0) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      _eaHighlight(Math.min(_eaState.selectedIdx + 1, opts.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      _eaHighlight(Math.max(_eaState.selectedIdx - 1, 0));
+    } else if (e.key === 'Enter' && _eaState.selectedIdx >= 0) {
+      e.preventDefault();
+      accept(opts[_eaState.selectedIdx].dataset.id);
+    } else if (e.key === 'Tab' && _eaState.selectedIdx >= 0) {
+      accept(opts[_eaState.selectedIdx].dataset.id);
+    }
+  });
+}
+
+// Module-level singleton state for the autocomplete dropdown. Only one
+// dropdown is ever alive at a time; these keep the global listeners
+// (scroll/resize) and the open/close/position/highlight helpers shared so
+// switching fields doesn't orphan dropdowns or double-register listeners.
+const _eaState = { dropdown: null, input: null, selectedIdx: -1, globalListenersAttached: false };
+
+function _eaClose() {
+  if (_eaState.dropdown) { _eaState.dropdown.remove(); _eaState.dropdown = null; }
+  _eaState.input = null;
+  _eaState.selectedIdx = -1;
+}
+
+// Uses position:fixed (viewport-relative) so it matches getBoundingClientRect
+// regardless of page or modal scroll — the old position:absolute version
+// drifted off-screen once the page was scrolled, leaving invisible divs that
+// stretched the document and produced phantom scrollbars.
+function _eaPosition() {
+  if (!_eaState.dropdown || !_eaState.input) return;
+  const rect = _eaState.input.getBoundingClientRect();
+  _eaState.dropdown.style.left = rect.left + 'px';
+  _eaState.dropdown.style.top = (rect.bottom + 2) + 'px';
+  _eaState.dropdown.style.width = rect.width + 'px';
+}
+
+function _eaHighlight(idx) {
+  if (!_eaState.dropdown) return;
+  const opts = _eaState.dropdown.querySelectorAll('.ea-item');
+  opts.forEach(o => o.classList.remove('ea-selected'));
+  if (idx >= 0 && idx < opts.length) {
+    opts[idx].classList.add('ea-selected');
+    opts[idx].scrollIntoView({ block: 'nearest' });
+    _eaState.selectedIdx = idx;
+  } else {
+    _eaState.selectedIdx = -1;
+  }
+}
+
 function renderTabs() {
   const tabsContainer = document.getElementById('tabs');
   tabsContainer.innerHTML = '';
@@ -241,17 +446,18 @@ function renderPreview() {
         </div>`;
     } else if (card.type === 'fan') {
       const o = card.options || {};
-      const presetModes = (o.preset_modes && o.preset_modes.length ? o.preset_modes : FAN_MOCK.preset_modes).filter(m => m.toLowerCase() !== 'off');
+      const mock = liveMock(o.entity_id, FAN_MOCK);
+      const presetModes = (o.preset_modes && o.preset_modes.length ? o.preset_modes : mock.preset_modes).filter(m => m.toLowerCase() !== 'off');
       const style = o.style || 'auto';
       const useFull = style === 'full' || (style !== 'simple' && (presetModes.length > 0 || true)); // mock always reports `oscillating`
-      const usingExample = !(o.preset_modes && o.preset_modes.length);
+      const usingExample = !(o.preset_modes && o.preset_modes.length) && !haEntity(o.entity_id);
       let bodyHtml;
       if (!useFull) {
         bodyHtml = `
           <div class="preview-fan-simple">
             <div>
-              <div class="fs-name">${o.name || o.entity_id || FAN_MOCK.friendly_name}</div>
-              <div class="fs-state">${FAN_MOCK.state === 'on' ? FAN_MOCK.percentage + '%' : 'Off'}</div>
+              <div class="fs-name">${o.name || haFriendlyName(o.entity_id) || mock.friendly_name}</div>
+              <div class="fs-state">${mock.state === 'on' ? mock.percentage + '%' : 'Off'}</div>
             </div>
             <div style="display:flex; gap:8px;">
               <div class="fx-pct-btn">−</div>
@@ -262,87 +468,101 @@ function renderPreview() {
         const showCaptions = o.show_captions !== false;
         const presetRows = climateBalancedRows(presetModes, 4).map(row => `
           <div class="fx-row">
-            ${row.map(m => `<div class="fx-chip ${FAN_MOCK.state === 'on' && m.toLowerCase() === FAN_MOCK.preset_mode.toLowerCase() ? 'fx-chip-selected' : ''}">${m}</div>`).join('')}
+            ${row.map(m => `<div class="fx-chip ${mock.state === 'on' && m.toLowerCase() === (mock.preset_mode || '').toLowerCase() ? 'fx-chip-selected' : ''}">${m}</div>`).join('')}
           </div>`).join('');
         bodyHtml = `
           <div class="preview-fan">
             <div class="fx-header">
-              <span class="fx-name">${o.name || o.entity_id || FAN_MOCK.friendly_name}</span>
-              <div class="fx-power ${FAN_MOCK.state === 'off' ? 'is-off' : ''}">${mdiSvg(MDI.power)}</div>
+              <span class="fx-name">${o.name || haFriendlyName(o.entity_id) || mock.friendly_name}</span>
+              <div class="fx-power ${mock.state === 'off' ? 'is-off' : ''}">${mdiSvg(MDI.power)}</div>
             </div>
             ${presetModes.length ? `${showCaptions ? '<div class="fx-caption">Preset</div>' : ''}${presetRows}` : `
               <div class="fx-pct-row">
                 <div class="fx-pct-btn">−</div>
-                <div class="fx-pct">${FAN_MOCK.percentage}%</div>
+                <div class="fx-pct">${mock.percentage}%</div>
                 <div class="fx-pct-btn">+</div>
               </div>`}
             ${showCaptions ? '<div class="fx-caption">Oscillate</div>' : ''}
-            <div class="fx-row"><div class="fx-chip ${FAN_MOCK.oscillating ? 'fx-chip-selected' : ''}" style="flex:1">${fanOscillateLabel(FAN_MOCK.oscillating)}</div></div>
+            <div class="fx-row"><div class="fx-chip ${mock.oscillating ? 'fx-chip-selected' : ''}" style="flex:1">${fanOscillateLabel(mock.oscillating)}</div></div>
           </div>`;
       }
       cardEl.innerHTML = `
         <div class="card">
           <div class="card-title"><span>fan</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
           ${bodyHtml}
-          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'fan.entity'} · Layout: ${style}${usingExample ? ' · example data (' + FAN_MOCK.friendly_name + ')' : ''}</div>
+          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'fan.entity'} · Layout: ${style}${usingExample ? ' · example data (' + mock.friendly_name + ')' : (haEntity(o.entity_id) ? ' · live HA data' : '')}</div>
         </div>`;
     } else if (card.type === 'vacuum') {
       const o = card.options || {};
+      const mock = liveMock(o.entity_id, VACUUM_MOCK);
       const rooms = o.rooms || [];
       cardEl.innerHTML = `
         <div class="card">
           <div class="card-title"><span>vacuum</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
           <div class="preview-vacuum">
             <div class="vc-header">
-              <span class="vc-name">${o.name || o.entity_id || VACUUM_MOCK.friendly_name}</span>
-              <span>${vacuumStateLabel(VACUUM_MOCK.state)}</span>
+              <span class="vc-name">${o.name || haFriendlyName(o.entity_id) || mock.friendly_name}</span>
+              <span>${vacuumStateLabel(mock.state)}</span>
             </div>
-            <div class="hint" style="margin-top:4px">Cleaning mode: ${vacuumPrettyLabel(VACUUM_MOCK.fan_speed)} (of ${VACUUM_MOCK.fan_speed_list.map(vacuumPrettyLabel).join(', ')})</div>
+            <div class="hint" style="margin-top:4px">Cleaning mode: ${vacuumPrettyLabel(mock.fan_speed)} (of ${(mock.fan_speed_list || []).map(vacuumPrettyLabel).join(', ')})</div>
             <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'vacuum.entity'}${o.map_image ? ' · Map: ' + o.map_image : ' · No map image'}${o.map_rotation ? ' · Rotated ' + o.map_rotation + '°' : ''} · ${o.map_height ?? 200}px</div>
             ${rooms.length ? `<div class="vc-rooms">${rooms.map(r => `<div class="vc-room">${r.name} (${r.id})</div>`).join('')}</div>` : '<div class="hint" style="margin-top:6px">No rooms configured — start/pause/dock/locate controls only.</div>'}
-            <div class="hint" style="margin-top:4px">example data (${VACUUM_MOCK.friendly_name})</div>
+            <div class="hint" style="margin-top:4px">${haEntity(o.entity_id) ? 'live HA data' : 'example data'} (${mock.friendly_name})</div>
           </div>
         </div>`;
     } else if (card.type === 'climate') {
       const o = card.options || {};
-      const hvacModes = (o.hvac_modes && o.hvac_modes.length ? o.hvac_modes : CLIMATE_MOCK.hvac_modes).filter(m => m !== 'off');
-      const fanModes = (o.fan_modes && o.fan_modes.length ? o.fan_modes : CLIMATE_MOCK.fan_modes);
-      const swingModes = (o.swing_modes && o.swing_modes.length ? o.swing_modes : CLIMATE_MOCK.swing_modes);
+      const mock = liveMock(o.entity_id, CLIMATE_MOCK);
+      const hvacModes = (o.hvac_modes && o.hvac_modes.length ? o.hvac_modes : (mock.hvac_modes || [])).filter(m => m !== 'off');
+      const fanModes = (o.fan_modes && o.fan_modes.length ? o.fan_modes : (mock.fan_modes || []));
+      const swingModes = (o.swing_modes && o.swing_modes.length ? o.swing_modes : (mock.swing_modes || []));
       const hvacStyle = o.hvac_mode_style === 'label' ? 'label' : 'icons';
       const fanStyle = o.fan_mode_style === 'icons' ? 'icons' : 'label';
       const swingStyle = o.swing_mode_style === 'icons' ? 'icons' : 'label';
-      const usingExample = !(o.hvac_modes && o.hvac_modes.length) && !(o.fan_modes && o.fan_modes.length) && !(o.swing_modes && o.swing_modes.length);
+      const usingExample = !(o.hvac_modes && o.hvac_modes.length) && !(o.fan_modes && o.fan_modes.length) && !(o.swing_modes && o.swing_modes.length) && !haEntity(o.entity_id);
       const showCaptions = o.show_captions !== false;
+      // heat_cool mode uses a temp range (target_temp_low..target_temp_high)
+      // instead of a single setpoint — temperature is null in that mode.
+      // Check the live entity directly: liveMock skips nulls, so the mock's
+      // default temperature (24) would mask the range otherwise.
+      const live = haEntity(o.entity_id);
+      const liveTempNull = live && live.attributes && 'temperature' in live.attributes && live.attributes.temperature == null;
+      const isRange = liveTempNull ? (mock.target_temp_high != null && mock.target_temp_low != null) : (mock.temperature == null && mock.target_temp_high != null && mock.target_temp_low != null);
+      const tempDisplay = isRange
+        ? `${mock.target_temp_low}-${mock.target_temp_high}°`
+        : (mock.temperature != null ? `${mock.temperature}°` : '—');
+      const tempClass = isRange ? 'cc-temp cc-temp-range' : 'cc-temp';
       cardEl.innerHTML = `
         <div class="card">
           <div class="card-title"><span>climate</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
           <div class="preview-climate">
             <div class="cc-header">
-              <span class="cc-name">${o.name || o.entity_id || 'Climate'}</span>
-              <div class="cc-power ${CLIMATE_MOCK.state === 'off' ? 'is-off' : ''}">${mdiSvg(MDI.power)}</div>
+              <span class="cc-name">${o.name || haFriendlyName(o.entity_id) || 'Climate'}</span>
+              <div class="cc-power ${mock.state === 'off' ? 'is-off' : ''}">${mdiSvg(MDI.power)}</div>
             </div>
             <div class="cc-temp-row">
               <div class="cc-stepper">−</div>
               <div class="cc-temp-col">
-                <div class="cc-temp">${CLIMATE_MOCK.temperature}°</div>
-                <div class="cc-current">Now ${CLIMATE_MOCK.current_temperature}°</div>
+                <div class="${tempClass}">${tempDisplay}</div>
+                <div class="cc-current">Now ${mock.current_temperature != null ? mock.current_temperature + '°' : ''}</div>
               </div>
               <div class="cc-stepper">+</div>
             </div>
-            ${hvacModes.length ? `${showCaptions ? '<div class="cc-caption">Mode</div>' : ''}${climateChipRowsHtml(hvacModes, CLIMATE_MOCK.state, hvacStyle, hvacStyle === 'icons' ? 5 : 3, climateHvacLabel, climateHvacIcon)}` : ''}
-            ${fanModes.length ? `${showCaptions ? '<div class="cc-caption">Fan</div>' : ''}${climateChipRowsHtml(fanModes, CLIMATE_MOCK.fan_mode, fanStyle, fanStyle === 'icons' ? 5 : 3, climateFanLabel, climateFanIcon)}` : ''}
-            ${swingModes.length ? `${showCaptions ? '<div class="cc-caption">Swing</div>' : ''}${climateChipRowsHtml(swingModes, CLIMATE_MOCK.swing_mode, swingStyle, swingStyle === 'icons' ? 5 : 3, climateSwingLabel, climateSwingIcon)}` : ''}
+            ${hvacModes.length ? `${showCaptions ? '<div class="cc-caption">Mode</div>' : ''}${climateChipRowsHtml(hvacModes, mock.state, hvacStyle, hvacStyle === 'icons' ? 5 : 3, climateHvacLabel, climateHvacIcon)}` : ''}
+            ${fanModes.length ? `${showCaptions ? '<div class="cc-caption">Fan</div>' : ''}${climateChipRowsHtml(fanModes, mock.fan_mode, fanStyle, fanStyle === 'icons' ? 5 : 3, climateFanLabel, climateFanIcon)}` : ''}
+            ${swingModes.length ? `${showCaptions ? '<div class="cc-caption">Swing</div>' : ''}${climateChipRowsHtml(swingModes, mock.swing_mode, swingStyle, swingStyle === 'icons' ? 5 : 3, climateSwingLabel, climateSwingIcon)}` : ''}
           </div>
-          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'climate.entity'}${usingExample ? ' · no overrides set — showing example modes (your real device\'s modes render live in the app)' : ''}</div>
+          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'climate.entity'}${haEntity(o.entity_id) ? ' · live HA data' : (usingExample ? ' · no overrides set — showing example modes (your real device\'s modes render live in the app)' : '')}</div>
         </div>`;
     } else if (card.type === 'cover') {
       const o = card.options || {};
-      const name = o.name || o.entity_id || COVER_MOCK.friendly_name;
-      const position = COVER_MOCK.current_position; // 0..100
-      const tilt = COVER_MOCK.current_tilt_position; // 0..100
-      const isOpen = position != null ? position >= 100 : COVER_MOCK.state === 'open';
-      const isClosed = position != null ? position <= 0 : COVER_MOCK.state === 'closed';
-      const stateLabel = coverPositionLabel(position, COVER_MOCK.state);
+      const mock = liveMock(o.entity_id, COVER_MOCK);
+      const name = o.name || haFriendlyName(o.entity_id) || mock.friendly_name;
+      const position = mock.current_position; // 0..100
+      const tilt = mock.current_tilt_position; // 0..100
+      const isOpen = position != null ? position >= 100 : mock.state === 'open';
+      const isClosed = position != null ? position <= 0 : mock.state === 'closed';
+      const stateLabel = coverPositionLabel(position, mock.state);
       const layout = (o.layout === 'horizontal' || o.layout === 'vertical') ? o.layout : 'default';
       // Only 2 icon variants exist (fully open / fully closed shutter) — show
       // "closed" only when truly closed (0%); anything else reads as "open"
@@ -428,7 +648,7 @@ function renderPreview() {
         <div class="card">
           <div class="card-title"><span>cover</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
           ${bodyHtml}
-          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'cover.entity'} · Layout: ${layout} · Controls: ${enabledControls.join(', ') || 'none'} · example data (${COVER_MOCK.friendly_name}, ${position}% open${ctrlTilt ? `, tilt ${tilt}%` : ''})</div>
+          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'cover.entity'} · Layout: ${layout} · Controls: ${enabledControls.join(', ') || 'none'} · ${haEntity(o.entity_id) ? 'live HA data' : 'example data'} (${mock.friendly_name}, ${position}% open${ctrlTilt ? `, tilt ${tilt}%` : ''})</div>
         </div>`;
     } else if (card.type === 'select') {
       const o = card.options || {};
@@ -490,9 +710,10 @@ function renderPreview() {
         </div>`;
     } else if (card.type === 'light') {
       const o = card.options || {};
-      const name = o.name || o.entity_id || LIGHT_MOCK.friendly_name;
-      const isOn = LIGHT_MOCK.state === 'on';
-      const brightnessPct = LIGHT_MOCK.brightness != null ? Math.round((LIGHT_MOCK.brightness / 255) * 100) : null;
+      const mock = liveMock(o.entity_id, LIGHT_MOCK);
+      const name = o.name || haFriendlyName(o.entity_id) || mock.friendly_name;
+      const isOn = mock.state === 'on';
+      const brightnessPct = mock.brightness != null ? Math.round((mock.brightness / 255) * 100) : null;
       const useLightColor = o.use_light_color === true;
       const showBrightness = o.show_brightness !== false;
       const layout = (o.layout === 'horizontal' || o.layout === 'vertical') ? o.layout : 'default';
@@ -502,7 +723,7 @@ function renderPreview() {
       // follows the light's rgb_color only when "use_light_color" is set,
       // otherwise the plain amber "on" look. This mock reports color_temp/xy
       // (no rgb_color of its own — see kelvinToPreviewRgb in mocks.js).
-      const [r, g, b] = LIGHT_MOCK.rgb_color || kelvinToPreviewRgb(LIGHT_MOCK.color_temp_kelvin);
+      const [r, g, b] = mock.rgb_color || kelvinToPreviewRgb(mock.color_temp_kelvin);
       const lightColorCss = (isOn && useLightColor) ? `rgb(${r},${g},${b})` : null;
       const iconPath = isOn ? MDI.lightbulbOn : MDI.lightbulbOff;
       const iconBg = !isOn ? 'var(--control)' : (lightColorCss ? `rgba(${r},${g},${b},0.22)` : 'var(--amber)');
@@ -512,7 +733,7 @@ function renderPreview() {
       // Mirrors LightCard.kt: if none of the 3 flags are set at all, fall
       // back to "brightness control only" so untouched configs preview
       // exactly as they always have.
-      const supportedModes = LIGHT_MOCK.supported_color_modes || [];
+      const supportedModes = mock.supported_color_modes || [];
       const supportsColor = supportedModes.some(m => ['hs', 'rgb', 'rgbw', 'rgbww', 'xy'].includes(m));
       const supportsColorTemp = supportedModes.includes('color_temp');
       const hasLightCtrlOpts = ('show_brightness_control' in o) || ('show_color_temp_control' in o) || ('show_color_control' in o);
@@ -540,7 +761,7 @@ function renderPreview() {
         </div>`;
       const colorTempSliderHtml = `
         <div class="pc-slider" style="background:linear-gradient(90deg,#FFB366,#FFF3E0,#9EC8FF)">
-          <div class="pc-slider-label" style="color:#241A00">${LIGHT_MOCK.color_temp_kelvin}K</div>
+          <div class="pc-slider-label" style="color:#241A00">${mock.color_temp_kelvin}K</div>
         </div>`;
       const colorSwatchesHtml = `
         <div class="pl-color-row">
@@ -591,18 +812,18 @@ function renderPreview() {
         <div class="card">
           <div class="card-title"><span>light</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
           ${bodyHtml}
-          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'light.entity'} · Layout: ${layout}${useLightColor ? ' · icon tinted with light colour' : ''} · Controls: ${enabledControls.join(', ') || 'none'}${collapsible ? ' (hidden while off)' : ''} · example data (${LIGHT_MOCK.friendly_name}, ${brightnessPct}%)</div>
+          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'light.entity'} · Layout: ${layout}${useLightColor ? ' · icon tinted with light colour' : ''} · Controls: ${enabledControls.join(', ') || 'none'}${collapsible ? ' (hidden while off)' : ''} · ${haEntity(o.entity_id) ? 'live HA data' : 'example data'} (${mock.friendly_name}, ${brightnessPct}%)</div>
         </div>`;
     } else if (card.type === 'media_player') {
       const o = card.options || {};
-      const mock = MEDIA_MOCK;
+      const mock = liveMock(o.entity_id, MEDIA_MOCK);
       const full = o.variant === 'full';
       const useMediaInfo = o.use_media_info !== false;
       const showVolumeLevel = o.show_volume_level === true;
       const mediaControls = (o.media_controls || 'previous,play_pause,next').split(',').map(s => s.trim()).filter(Boolean);
       const volumeControls = (o.volume_controls || 'mute,buttons').split(',').map(s => s.trim()).filter(Boolean);
 
-      const title = useMediaInfo ? (mock.media_title || o.name || mock.friendly_name) : (o.name || mock.friendly_name);
+      const title = useMediaInfo ? (mock.media_title || o.name || haFriendlyName(o.entity_id) || mock.friendly_name) : (o.name || haFriendlyName(o.entity_id) || mock.friendly_name);
       const subtitle = useMediaInfo ? (mock.media_artist || mock.app_name) : null;
       let stateLine = subtitle || mediaStateLabel(mock.state);
       if (showVolumeLevel) stateLine += ` ⸱ ${Math.round((mock.volume_level || 0) * 100)}%`;
@@ -668,7 +889,7 @@ function renderPreview() {
         <div class="card">
           <div class="card-title"><span>media_player (${full ? 'full' : 'compact'})</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
           ${bodyHtml}
-          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'media_player.entity'} · example data (${mock.friendly_name}, ${mock.state}) · long-press the compact tile in-app opens the detail dialog</div>
+          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'media_player.entity'} · ${haEntity(o.entity_id) ? 'live HA data' : 'example data'} (${mock.friendly_name}, ${mock.state}) · long-press the compact tile in-app opens the detail dialog</div>
         </div>`;
     } else if (card.type === 'button_grid' || card.type === 'scene_grid') {
       const isScene = card.type === 'scene_grid';
@@ -753,7 +974,7 @@ function renderPreview() {
       cardEl.className = 'card';
       cardEl.innerHTML = `
         <div class="card-title"><span>${card.type}</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
-        <div><strong>${card.options?.name || card.options?.entity_id || card.type}</strong><br>
+        <div><strong>${card.options?.name || haFriendlyName(card.options?.entity_id) || card.options?.entity_id || card.type}</strong><br>
         <small style="color:#888">${card.options?.entity_id || card.options?.remote_entity || ''}</small></div>`;
     }
     contentContainer.appendChild(cardEl);

--- a/app/src/main/java/com/custom/astrion/MainActivity.kt
+++ b/app/src/main/java/com/custom/astrion/MainActivity.kt
@@ -191,6 +191,7 @@ class MainActivity : ComponentActivity() {
         configServer = ConfigServer(
             context = this,
             harmonyRegistry = harmonyRegistry,
+            haClient = client,
             onConnectionSaved = { runOnUiThread { reconnectWithNewSettings() } },
             onDashboardUpdated = { runOnUiThread { reloadDashboard() } },
             getPageNames = { dashboard.config.pages.map { it.name } },

--- a/app/src/main/java/com/custom/astrion/cards/impl/ClimateCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/ClimateCard.kt
@@ -146,8 +146,8 @@ class ClimateCard : CardRenderer {
         // deadband intact. HA's set_temperature service accepts
         // target_temp_high/target_temp_low for range mode.
         fun shiftRange(delta: Double) {
-            val lo = (targetLow!! + delta).coerceIn(minT ?: targetLow, maxT ?: targetLow)
-            val hi = (targetHigh!! + delta).coerceIn(minT ?: targetHigh, maxT ?: targetHigh)
+            val lo = (targetLow!! + delta).coerceIn(minT ?: Double.NEGATIVE_INFINITY, maxT ?: Double.POSITIVE_INFINITY)
+            val hi = (targetHigh!! + delta).coerceIn(minT ?: Double.NEGATIVE_INFINITY, maxT ?: Double.POSITIVE_INFINITY)
             ctx.client.callService(
                 ServiceCall.of("climate", "set_temperature", entityId,
                     "target_temp_low" to lo, "target_temp_high" to hi),

--- a/app/src/main/java/com/custom/astrion/cards/impl/ClimateCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/ClimateCard.kt
@@ -100,8 +100,13 @@ class ClimateCard : CardRenderer {
         val maxT = e?.attrDouble("max_temp")
 
         val target = e?.attrDouble("temperature")
+        val targetHigh = e?.attrDouble("target_temp_high")
+        val targetLow = e?.attrDouble("target_temp_low")
         val current = e?.attrDouble("current_temperature")
         val mode = e?.state ?: "off"
+        // heat_cool mode uses a temp range (target_temp_low..target_temp_high)
+        // instead of a single setpoint — temperature is null in that mode.
+        val isRange = target == null && targetHigh != null && targetLow != null
         // "off" is deliberately excluded — the header's dedicated power
         // button already turns the unit off, so a chip for it would just
         // duplicate that control.
@@ -134,6 +139,18 @@ class ClimateCard : CardRenderer {
             val clamped = t.coerceIn(minT ?: t, maxT ?: t)
             ctx.client.callService(
                 ServiceCall.of("climate", "set_temperature", entityId, "temperature" to clamped),
+            )
+        }
+
+        // In heat_cool mode, shift both bounds together by `delta` — keeps the
+        // deadband intact. HA's set_temperature service accepts
+        // target_temp_high/target_temp_low for range mode.
+        fun shiftRange(delta: Double) {
+            val lo = (targetLow!! + delta).coerceIn(minT ?: targetLow, maxT ?: targetLow)
+            val hi = (targetHigh!! + delta).coerceIn(minT ?: targetHigh, maxT ?: targetHigh)
+            ctx.client.callService(
+                ServiceCall.of("climate", "set_temperature", entityId,
+                    "target_temp_low" to lo, "target_temp_high" to hi),
             )
         }
 
@@ -201,13 +218,19 @@ class ClimateCard : CardRenderer {
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Stepper(Icons.Filled.Remove, ctx.theme) { target?.let { setTemp(it - step) } }
+                Stepper(Icons.Filled.Remove, ctx.theme) {
+                    if (isRange) shiftRange(-step) else target?.let { setTemp(it - step) }
+                }
 
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
                     Text(
-                        target?.let { "${trim(it)}°" } ?: "—",
+                        when {
+                            isRange -> "${trim(targetLow!!)}-${trim(targetHigh!!)}°"
+                            target != null -> "${trim(target)}°"
+                            else -> "—"
+                        },
                         color = ctx.theme.primaryText,
-                        fontSize = 36.sp,
+                        fontSize = if (isRange) 28.sp else 36.sp,
                         fontWeight = FontWeight.Bold,
                     )
                     Text(
@@ -217,7 +240,9 @@ class ClimateCard : CardRenderer {
                     )
                 }
 
-                Stepper(Icons.Filled.Add, ctx.theme) { target?.let { setTemp(it + step) } }
+                Stepper(Icons.Filled.Add, ctx.theme) {
+                    if (isRange) shiftRange(step) else target?.let { setTemp(it + step) }
+                }
             }
 
             // HVAC mode chips (icons by default, matching HA's tile card; "off" excluded, see above).

--- a/app/src/main/java/com/custom/astrion/web/Configserver.kt
+++ b/app/src/main/java/com/custom/astrion/web/Configserver.kt
@@ -14,11 +14,17 @@ import com.custom.astrion.config.ActivityRuntime
 import com.custom.astrion.config.DashboardLoader
 import com.custom.astrion.config.HarmonyHubConfig
 import com.custom.astrion.config.RemoteSettings
+import com.custom.astrion.ha.ConnectionState
+import com.custom.astrion.ha.HaClient
 import com.custom.astrion.harmony.HarmonyHubDiscovery
 import com.custom.astrion.harmony.HarmonyHubRegistry
 import com.custom.astrion.update.UpdateChecker
 import fi.iki.elonen.NanoHTTPD
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONArray
@@ -51,6 +57,10 @@ import java.util.UUID
  *                        (?entity=<id>) through this device's HA token, as
  *                        image/jpeg — lets the editor preview show a real
  *                        camera frame (the browser has no HA token of its own)
+ *  GET  /ha-states       snapshot of every HA entity this device currently knows
+ *                        ({entity_id: {state, friendly_name, attributes}}) plus
+ *                        a `connected` flag — lets the dashboard editor preview
+ *                        render with live HA data instead of the static mocks
  *  GET  /dashboard.json  download the current dashboard.json (backup)
  *  POST /dashboard.json  replace dashboard.json, then live-reload the dashboard
  *  POST /icons           upload a PNG into /sdcard/astrion/icons/
@@ -107,6 +117,7 @@ import java.util.UUID
 class ConfigServer(
     private val context: Context,
     private val harmonyRegistry: HarmonyHubRegistry,
+    private val haClient: HaClient,
     private val onConnectionSaved: () -> Unit,
     private val onDashboardUpdated: () -> Unit,
     /** Current dashboard's page names, in pager order — read fresh on every
@@ -152,6 +163,7 @@ class ConfigServer(
                 "/harmony-hubs" -> if (method == Method.GET) serveHarmonyHubs() else methodNotAllowed()
                 "/harmony-discover" -> if (method == Method.GET) serveHarmonyDiscover(session) else methodNotAllowed()
                 "/camera-snapshot" -> if (method == Method.GET) serveCameraSnapshot(session) else methodNotAllowed()
+                "/ha-states" -> if (method == Method.GET) serveHaStates() else methodNotAllowed()
                 "/icons-list" -> if (method == Method.GET) serveIconsList() else methodNotAllowed()
                 "/check-update" -> if (method == Method.GET) handleCheckUpdate() else methodNotAllowed()
                 "/save-connection" -> if (method == Method.POST) handleSaveConnection(session) else methodNotAllowed()
@@ -863,6 +875,45 @@ class ConfigServer(
             newFixedLengthResponse(Response.Status.OK, "image/jpeg", ByteArrayInputStream(bytes), bytes.size.toLong())
         resp.addHeader("Cache-Control", "no-store")
         return resp
+    }
+
+    /**
+     * Snapshot of every HA entity the running app currently holds, as JSON the
+     * dashboard editor (docs/js/preview.js) can render against instead of the
+     * static `*_MOCK` examples. Shape:
+     *   { "connected": true, "states": { "cover.x": { "state": "open",
+     *       "friendly_name": "X", "attributes": { ... } }, ... } }
+     *
+     * `connected` reflects the WebSocket state at call time; the editor falls
+     * back to the mocks when it's false (or when this endpoint isn't reachable,
+     * e.g. the GitHub Pages copy of the editor). Attributes are passed through
+     * verbatim (the same kotlinx JsonObject the cards read), so each card's
+     * preview can pull whatever domain-specific fields it needs.
+     */
+    private fun serveHaStates(): Response {
+        val connected = haClient.connection.value == ConnectionState.CONNECTED
+        val entities = haClient.entities.value
+        val json =
+            buildJsonObject {
+                put("connected", connected)
+                put(
+                    "states",
+                    buildJsonObject {
+                        entities.forEach { (id, e) ->
+                            put(
+                                id,
+                                buildJsonObject {
+                                    put("state", e.state)
+                                    put("friendly_name", e.friendlyName)
+                                    put("attributes", e.attributes)
+                                },
+                            )
+                        }
+                    },
+                )
+            }
+        val body = Json.encodeToString(JsonObject.serializer(), json)
+        return newFixedLengthResponse(Response.Status.OK, "application/json", body)
     }
 
     // ---- actions --------------------------------------------------------------

--- a/docs/js/cards.js
+++ b/docs/js/cards.js
@@ -289,6 +289,26 @@ function updateCardFormInputs() {
       <div class="hint">This card type isn't fully modeled in the builder yet — paste the options object directly.</div>
     `;
   }
+
+  // Attach live entity autocomplete to whichever entity_id fields this card
+  // type created. Only attaches when /ha-states data is available (device mode
+  // + HA connected); otherwise the inputs stay plain text fields.
+  const mainDomain = type === 'clock_weather' ? 'weather'
+    : type === 'source_select' ? null
+    : type;
+  ['optEntityId', 'optRemoteEntity', 'optMediaEntity', 'optMuteEntity',
+    'optCalendarEntity', 'optMapImage', 'giEntityId'].forEach(id => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const dom = id === 'optEntityId' ? mainDomain
+      : id === 'optRemoteEntity' ? 'remote'
+      : id === 'optMediaEntity' ? 'media_player'
+      : id === 'optMuteEntity' ? 'media_player'
+      : id === 'optCalendarEntity' ? 'calendar'
+      : id === 'optMapImage' ? 'image'
+      : null; // giEntityId — any domain (scene.*, script.*, media_player.*, …)
+    attachEntityAutocomplete(el, dom);
+  });
 }
 
 // media_player card: top_buttons only make sense on the "full" variant

--- a/docs/js/cards.js
+++ b/docs/js/cards.js
@@ -295,6 +295,7 @@ function updateCardFormInputs() {
   // + HA connected); otherwise the inputs stay plain text fields.
   const mainDomain = type === 'clock_weather' ? 'weather'
     : type === 'source_select' ? null
+    : type === 'select' ? ['select', 'input_select']
     : type;
   ['optEntityId', 'optRemoteEntity', 'optMediaEntity', 'optMuteEntity',
     'optCalendarEntity', 'optMapImage', 'giEntityId'].forEach(id => {

--- a/docs/js/device.js
+++ b/docs/js/device.js
@@ -26,17 +26,44 @@ async function loadDashboardFromDevice() {
   try {
     const res = await fetch('/dashboard.json');
     deviceModeAvailable = true; // reaching this line at all means the app answered — even a 404 (no dashboard.json saved yet) still confirms device mode
+    await loadHaStates(); // best-effort: lets the preview render with live HA data instead of the static mocks
     if (res.ok) {
       const parsed = await res.json();
       applyParsedDashboard(parsed);
       initEditor();
       console.log('Loaded dashboard.json from this device.');
+    } else {
+      // No dashboard.json yet — the inline initEditor() already ran with the
+      // default empty page; just refresh the preview now that haStates is loaded.
+      renderPreview();
     }
   } catch (e) {
     deviceModeAvailable = false;
     console.log('Not served by the app (or offline) — using the paste/download flow instead.', e);
   }
   updateDeviceModeUi();
+}
+
+/**
+ * Fetches a snapshot of every HA entity the device currently knows, exposed
+ * by the app at /ha-states. Sets the global `haStates` (declared in preview.js)
+ * so the card renderers can use live state/names/attributes instead of the
+ * static *_MOCK examples. Failures are swallowed: on GitHub Pages or when HA
+ * is unreachable, haStates stays null and the preview quietly falls back to
+ * the mocks + prettyEntityName().
+ */
+async function loadHaStates() {
+  try {
+    const res = await fetch('/ha-states');
+    if (!res.ok) return;
+    const data = await res.json();
+    haStates = (data && data.states) ? data.states : null;
+    if (data && data.connected === false) {
+      console.log('HA not connected — preview will use example data.');
+    }
+  } catch (e) {
+    haStates = null; // not device mode, or older app build without the endpoint
+  }
 }
 
 /** Normalizes a parsed dashboard.json into dashboardData — same shape importJson() builds,

--- a/docs/js/mocks.js
+++ b/docs/js/mocks.js
@@ -41,6 +41,42 @@ const MDI = {
 };
 function mdiSvg(path) { return `<svg viewBox="0 0 24 24" fill="currentColor"><path d="${path}"/></svg>`; }
 
+// Mimics Home Assistant's default friendly_name generation: strip the domain
+// prefix, replace underscores with spaces, and title-case each word. Used by
+// the preview as a stand-in for the live friendly_name the app fetches from HA
+// (which the static editor page can't reach).
+function prettyEntityName(entityId) {
+  if (!entityId || typeof entityId !== 'string') return null;
+  const tail = entityId.includes('.') ? entityId.slice(entityId.indexOf('.') + 1) : entityId;
+  return tail.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+// Builds a per-card "mock" object for the preview that's live where possible:
+// starts from the static `baseMock` (so every field a renderer expects still
+// exists), then overlays the matching HA entity's real `state`, `friendly_name`
+// and `attributes` (which use the same HA attribute keys — brightness,
+// current_position, hvac_mode, supported_features, … — the renderers already
+// read off the mock). Returns `baseMock` unchanged when there's no live entity
+// for `entityId` (no HA connection, unknown entity, or not device mode), so
+// every renderer falls back to the example data it always showed.
+function liveMock(entityId, baseMock) {
+  const e = (typeof haEntity === 'function') ? haEntity(entityId) : null;
+  if (!e) return baseMock;
+  // Merge attributes over the mock, but skip null values — HA sends null for
+  // attributes a climate/cover/etc. doesn't currently have (e.g. temperature
+  // on a heat_cool thermostat with no setpoint), and those shouldn't clobber
+  // the mock's sane defaults (otherwise the preview renders "null°").
+  const merged = Object.assign({}, baseMock);
+  if (e.attributes) {
+    for (const k in e.attributes) {
+      if (e.attributes[k] != null) merged[k] = e.attributes[k];
+    }
+  }
+  merged.state = e.state;
+  merged.friendly_name = e.friendly_name || baseMock.friendly_name;
+  return merged;
+}
+
 function climateHvacIcon(m) {
   if (m === 'heat') return MDI.fire;
   if (m === 'cool') return MDI.snowflake;

--- a/docs/js/preview.js
+++ b/docs/js/preview.js
@@ -50,14 +50,16 @@ function haAttrStr(entityId, key) {
 //
 // `domain` filters candidates to entity_ids starting with "<domain>." — pass
 // null to offer every entity (used by scene_grid/button_grid where the entity
-// can be scene.*, script.*, media_player.*, …).
+// can be scene.*, script.*, media_player.*, …). Pass an array of strings to
+// match multiple domains (e.g. ['select', 'input_select'] for the select card).
 
 function attachEntityAutocomplete(inputEl, domain) {
   if (!inputEl || !haStates) return;
 
-  const prefix = domain ? domain + '.' : '';
+  const domains = Array.isArray(domain) ? domain : (domain ? [domain] : null);
+  const prefixes = domains ? domains.map(d => d + '.') : null;
   const items = Object.keys(haStates)
-    .filter(id => !prefix || id.startsWith(prefix))
+    .filter(id => !prefixes || prefixes.some(p => id.startsWith(p)))
     .map(id => ({
       id,
       name: haStates[id].friendly_name || id,

--- a/docs/js/preview.js
+++ b/docs/js/preview.js
@@ -1,5 +1,210 @@
 // ---- Preview ----------------------------------------------------------------
 
+// Live HA entity states, populated by loadHaStates() in device.js when the
+// editor is served by the app (http://<device-ip>:8080/builder/). null until
+// the fetch completes (or fails / not device mode) — renderers fall back to
+// the static *_MOCK examples then. Shape: { entity_id: { state, friendly_name,
+// attributes: {...} } }.
+let haStates = null;
+
+// Returns the live EntityState object for an entity_id, or null when no live
+// data is available (no HA connection, unknown entity, or not device mode).
+function haEntity(entityId) {
+  if (!entityId || !haStates) return null;
+  return haStates[entityId] || null;
+}
+
+// Live friendly_name for an entity, falling back to prettyEntityName() when we
+// have the entity but HA didn't send a friendly_name. null when no live data.
+function haFriendlyName(entityId) {
+  const e = haEntity(entityId);
+  if (!e) return null;
+  return e.friendly_name || prettyEntityName(entityId);
+}
+
+// Numeric attribute helper for live entities (mirrors HaModels.attrDouble).
+function haAttrNum(entityId, key) {
+  const e = haEntity(entityId);
+  if (!e || !e.attributes) return null;
+  const v = e.attributes[key];
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+// String attribute helper for live entities.
+function haAttrStr(entityId, key) {
+  const e = haEntity(entityId);
+  if (!e || !e.attributes) return null;
+  const v = e.attributes[key];
+  return v == null ? null : String(v);
+}
+
+// ---- Entity ID autocomplete for the card edit form --------------------------
+//
+// Attaches a custom dropdown to an <input> that lists matching HA entities
+// (filtered by domain) from the live /ha-states data. The user types to
+// narrow the list, clicks (or arrow-keys + Enter) to accept. Falls back to a
+// plain text input when haStates is null (no HA connection, or the editor is
+// opened from GitHub Pages instead of the device's own /builder/).
+//
+// `domain` filters candidates to entity_ids starting with "<domain>." — pass
+// null to offer every entity (used by scene_grid/button_grid where the entity
+// can be scene.*, script.*, media_player.*, …).
+
+function attachEntityAutocomplete(inputEl, domain) {
+  if (!inputEl || !haStates) return;
+
+  const prefix = domain ? domain + '.' : '';
+  const items = Object.keys(haStates)
+    .filter(id => !prefix || id.startsWith(prefix))
+    .map(id => ({
+      id,
+      name: haStates[id].friendly_name || id,
+      lower: id.toLowerCase(),
+      nameLower: (haStates[id].friendly_name || id).toLowerCase(),
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  let debounceTimer = null;
+  let suppressOpen = false; // set by accept() so the input event it dispatches doesn't immediately reopen
+
+  // Singleton: only one dropdown exists at a time across all inputs. Closing
+  // the previous (if any) on open prevents stray invisible dropdowns from
+  // accumulating when focus moves between fields.
+  if (!_eaState.globalListenersAttached) {
+    _eaState.globalListenersAttached = true;
+    // Capture phase so we also catch scrolls originating inside scrolling
+    // containers (the card-edit modal has its own internal scroll, which
+    // doesn't bubble to window).
+    document.addEventListener('scroll', () => {
+      if (_eaState.dropdown && _eaState.input) {
+        const r = _eaState.input.getBoundingClientRect();
+        if (r.bottom < 0 || r.top > window.innerHeight) _eaClose();
+ else _eaPosition();
+      }
+    }, { passive: true, capture: true });
+    window.addEventListener('resize', () => { if (_eaState.dropdown) _eaPosition(); });
+  }
+
+  function closeDropdown() { _eaClose(); }
+
+  function openDropdown(query) {
+    _eaClose();
+    const q = (query || '').toLowerCase();
+    const matches = q
+      ? items.filter(it => it.lower.includes(q) || it.nameLower.includes(q))
+      : items;
+    if (matches.length === 0) return;
+
+    const dd = document.createElement('div');
+    dd.className = 'ea-dropdown';
+
+    const maxShow = 60;
+    matches.slice(0, maxShow).forEach((it) => {
+      const row = document.createElement('div');
+      row.className = 'ea-item';
+      row.dataset.id = it.id;
+      row.innerHTML =
+        `<span class="ea-id">${it.id}</span>` +
+        `<span class="ea-name">${it.name}</span>`;
+      row.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        accept(it.id);
+      });
+      dd.appendChild(row);
+    });
+    if (matches.length > maxShow) {
+      const more = document.createElement('div');
+      more.className = 'ea-more';
+      more.textContent = (matches.length - maxShow) + ' more — keep typing to narrow';
+      dd.appendChild(more);
+    }
+
+    document.body.appendChild(dd);
+    _eaState.dropdown = dd;
+    _eaState.input = inputEl;
+    _eaState.selectedIdx = -1;
+    _eaPosition();
+  }
+
+  function accept(id) {
+    inputEl.value = id;
+    closeDropdown();
+    suppressOpen = true;
+    inputEl.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  inputEl.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    if (suppressOpen) { suppressOpen = false; return; }
+    debounceTimer = setTimeout(() => openDropdown(inputEl.value), 80);
+  });
+  inputEl.addEventListener('focus', () => openDropdown(inputEl.value));
+  inputEl.addEventListener('blur', () => setTimeout(() => {
+    // Only close if focus has actually left this input — clicking a dropdown
+    // item triggers a brief blur before mousedown, but preventDefault on the
+    // item's mousedown keeps focus here, so this blur closes only on a real
+    // focus shift to something else.
+    if (_eaState.input === inputEl) _eaClose();
+  }, 150));
+  inputEl.addEventListener('keydown', (e) => {
+    if (!_eaState.dropdown || _eaState.input !== inputEl) return;
+    if (e.key === 'Escape') { closeDropdown(); return; }
+    const opts = _eaState.dropdown.querySelectorAll('.ea-item');
+    if (opts.length === 0) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      _eaHighlight(Math.min(_eaState.selectedIdx + 1, opts.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      _eaHighlight(Math.max(_eaState.selectedIdx - 1, 0));
+    } else if (e.key === 'Enter' && _eaState.selectedIdx >= 0) {
+      e.preventDefault();
+      accept(opts[_eaState.selectedIdx].dataset.id);
+    } else if (e.key === 'Tab' && _eaState.selectedIdx >= 0) {
+      accept(opts[_eaState.selectedIdx].dataset.id);
+    }
+  });
+}
+
+// Module-level singleton state for the autocomplete dropdown. Only one
+// dropdown is ever alive at a time; these keep the global listeners
+// (scroll/resize) and the open/close/position/highlight helpers shared so
+// switching fields doesn't orphan dropdowns or double-register listeners.
+const _eaState = { dropdown: null, input: null, selectedIdx: -1, globalListenersAttached: false };
+
+function _eaClose() {
+  if (_eaState.dropdown) { _eaState.dropdown.remove(); _eaState.dropdown = null; }
+  _eaState.input = null;
+  _eaState.selectedIdx = -1;
+}
+
+// Uses position:fixed (viewport-relative) so it matches getBoundingClientRect
+// regardless of page or modal scroll — the old position:absolute version
+// drifted off-screen once the page was scrolled, leaving invisible divs that
+// stretched the document and produced phantom scrollbars.
+function _eaPosition() {
+  if (!_eaState.dropdown || !_eaState.input) return;
+  const rect = _eaState.input.getBoundingClientRect();
+  _eaState.dropdown.style.left = rect.left + 'px';
+  _eaState.dropdown.style.top = (rect.bottom + 2) + 'px';
+  _eaState.dropdown.style.width = rect.width + 'px';
+}
+
+function _eaHighlight(idx) {
+  if (!_eaState.dropdown) return;
+  const opts = _eaState.dropdown.querySelectorAll('.ea-item');
+  opts.forEach(o => o.classList.remove('ea-selected'));
+  if (idx >= 0 && idx < opts.length) {
+    opts[idx].classList.add('ea-selected');
+    opts[idx].scrollIntoView({ block: 'nearest' });
+    _eaState.selectedIdx = idx;
+  } else {
+    _eaState.selectedIdx = -1;
+  }
+}
+
 function renderTabs() {
   const tabsContainer = document.getElementById('tabs');
   tabsContainer.innerHTML = '';
@@ -241,17 +446,18 @@ function renderPreview() {
         </div>`;
     } else if (card.type === 'fan') {
       const o = card.options || {};
-      const presetModes = (o.preset_modes && o.preset_modes.length ? o.preset_modes : FAN_MOCK.preset_modes).filter(m => m.toLowerCase() !== 'off');
+      const mock = liveMock(o.entity_id, FAN_MOCK);
+      const presetModes = (o.preset_modes && o.preset_modes.length ? o.preset_modes : mock.preset_modes).filter(m => m.toLowerCase() !== 'off');
       const style = o.style || 'auto';
       const useFull = style === 'full' || (style !== 'simple' && (presetModes.length > 0 || true)); // mock always reports `oscillating`
-      const usingExample = !(o.preset_modes && o.preset_modes.length);
+      const usingExample = !(o.preset_modes && o.preset_modes.length) && !haEntity(o.entity_id);
       let bodyHtml;
       if (!useFull) {
         bodyHtml = `
           <div class="preview-fan-simple">
             <div>
-              <div class="fs-name">${o.name || o.entity_id || FAN_MOCK.friendly_name}</div>
-              <div class="fs-state">${FAN_MOCK.state === 'on' ? FAN_MOCK.percentage + '%' : 'Off'}</div>
+              <div class="fs-name">${o.name || haFriendlyName(o.entity_id) || mock.friendly_name}</div>
+              <div class="fs-state">${mock.state === 'on' ? mock.percentage + '%' : 'Off'}</div>
             </div>
             <div style="display:flex; gap:8px;">
               <div class="fx-pct-btn">−</div>
@@ -262,87 +468,101 @@ function renderPreview() {
         const showCaptions = o.show_captions !== false;
         const presetRows = climateBalancedRows(presetModes, 4).map(row => `
           <div class="fx-row">
-            ${row.map(m => `<div class="fx-chip ${FAN_MOCK.state === 'on' && m.toLowerCase() === FAN_MOCK.preset_mode.toLowerCase() ? 'fx-chip-selected' : ''}">${m}</div>`).join('')}
+            ${row.map(m => `<div class="fx-chip ${mock.state === 'on' && m.toLowerCase() === (mock.preset_mode || '').toLowerCase() ? 'fx-chip-selected' : ''}">${m}</div>`).join('')}
           </div>`).join('');
         bodyHtml = `
           <div class="preview-fan">
             <div class="fx-header">
-              <span class="fx-name">${o.name || o.entity_id || FAN_MOCK.friendly_name}</span>
-              <div class="fx-power ${FAN_MOCK.state === 'off' ? 'is-off' : ''}">${mdiSvg(MDI.power)}</div>
+              <span class="fx-name">${o.name || haFriendlyName(o.entity_id) || mock.friendly_name}</span>
+              <div class="fx-power ${mock.state === 'off' ? 'is-off' : ''}">${mdiSvg(MDI.power)}</div>
             </div>
             ${presetModes.length ? `${showCaptions ? '<div class="fx-caption">Preset</div>' : ''}${presetRows}` : `
               <div class="fx-pct-row">
                 <div class="fx-pct-btn">−</div>
-                <div class="fx-pct">${FAN_MOCK.percentage}%</div>
+                <div class="fx-pct">${mock.percentage}%</div>
                 <div class="fx-pct-btn">+</div>
               </div>`}
             ${showCaptions ? '<div class="fx-caption">Oscillate</div>' : ''}
-            <div class="fx-row"><div class="fx-chip ${FAN_MOCK.oscillating ? 'fx-chip-selected' : ''}" style="flex:1">${fanOscillateLabel(FAN_MOCK.oscillating)}</div></div>
+            <div class="fx-row"><div class="fx-chip ${mock.oscillating ? 'fx-chip-selected' : ''}" style="flex:1">${fanOscillateLabel(mock.oscillating)}</div></div>
           </div>`;
       }
       cardEl.innerHTML = `
         <div class="card">
           <div class="card-title"><span>fan</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
           ${bodyHtml}
-          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'fan.entity'} · Layout: ${style}${usingExample ? ' · example data (' + FAN_MOCK.friendly_name + ')' : ''}</div>
+          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'fan.entity'} · Layout: ${style}${usingExample ? ' · example data (' + mock.friendly_name + ')' : (haEntity(o.entity_id) ? ' · live HA data' : '')}</div>
         </div>`;
     } else if (card.type === 'vacuum') {
       const o = card.options || {};
+      const mock = liveMock(o.entity_id, VACUUM_MOCK);
       const rooms = o.rooms || [];
       cardEl.innerHTML = `
         <div class="card">
           <div class="card-title"><span>vacuum</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
           <div class="preview-vacuum">
             <div class="vc-header">
-              <span class="vc-name">${o.name || o.entity_id || VACUUM_MOCK.friendly_name}</span>
-              <span>${vacuumStateLabel(VACUUM_MOCK.state)}</span>
+              <span class="vc-name">${o.name || haFriendlyName(o.entity_id) || mock.friendly_name}</span>
+              <span>${vacuumStateLabel(mock.state)}</span>
             </div>
-            <div class="hint" style="margin-top:4px">Cleaning mode: ${vacuumPrettyLabel(VACUUM_MOCK.fan_speed)} (of ${VACUUM_MOCK.fan_speed_list.map(vacuumPrettyLabel).join(', ')})</div>
+            <div class="hint" style="margin-top:4px">Cleaning mode: ${vacuumPrettyLabel(mock.fan_speed)} (of ${(mock.fan_speed_list || []).map(vacuumPrettyLabel).join(', ')})</div>
             <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'vacuum.entity'}${o.map_image ? ' · Map: ' + o.map_image : ' · No map image'}${o.map_rotation ? ' · Rotated ' + o.map_rotation + '°' : ''} · ${o.map_height ?? 200}px</div>
             ${rooms.length ? `<div class="vc-rooms">${rooms.map(r => `<div class="vc-room">${r.name} (${r.id})</div>`).join('')}</div>` : '<div class="hint" style="margin-top:6px">No rooms configured — start/pause/dock/locate controls only.</div>'}
-            <div class="hint" style="margin-top:4px">example data (${VACUUM_MOCK.friendly_name})</div>
+            <div class="hint" style="margin-top:4px">${haEntity(o.entity_id) ? 'live HA data' : 'example data'} (${mock.friendly_name})</div>
           </div>
         </div>`;
     } else if (card.type === 'climate') {
       const o = card.options || {};
-      const hvacModes = (o.hvac_modes && o.hvac_modes.length ? o.hvac_modes : CLIMATE_MOCK.hvac_modes).filter(m => m !== 'off');
-      const fanModes = (o.fan_modes && o.fan_modes.length ? o.fan_modes : CLIMATE_MOCK.fan_modes);
-      const swingModes = (o.swing_modes && o.swing_modes.length ? o.swing_modes : CLIMATE_MOCK.swing_modes);
+      const mock = liveMock(o.entity_id, CLIMATE_MOCK);
+      const hvacModes = (o.hvac_modes && o.hvac_modes.length ? o.hvac_modes : (mock.hvac_modes || [])).filter(m => m !== 'off');
+      const fanModes = (o.fan_modes && o.fan_modes.length ? o.fan_modes : (mock.fan_modes || []));
+      const swingModes = (o.swing_modes && o.swing_modes.length ? o.swing_modes : (mock.swing_modes || []));
       const hvacStyle = o.hvac_mode_style === 'label' ? 'label' : 'icons';
       const fanStyle = o.fan_mode_style === 'icons' ? 'icons' : 'label';
       const swingStyle = o.swing_mode_style === 'icons' ? 'icons' : 'label';
-      const usingExample = !(o.hvac_modes && o.hvac_modes.length) && !(o.fan_modes && o.fan_modes.length) && !(o.swing_modes && o.swing_modes.length);
+      const usingExample = !(o.hvac_modes && o.hvac_modes.length) && !(o.fan_modes && o.fan_modes.length) && !(o.swing_modes && o.swing_modes.length) && !haEntity(o.entity_id);
       const showCaptions = o.show_captions !== false;
+      // heat_cool mode uses a temp range (target_temp_low..target_temp_high)
+      // instead of a single setpoint — temperature is null in that mode.
+      // Check the live entity directly: liveMock skips nulls, so the mock's
+      // default temperature (24) would mask the range otherwise.
+      const live = haEntity(o.entity_id);
+      const liveTempNull = live && live.attributes && 'temperature' in live.attributes && live.attributes.temperature == null;
+      const isRange = liveTempNull ? (mock.target_temp_high != null && mock.target_temp_low != null) : (mock.temperature == null && mock.target_temp_high != null && mock.target_temp_low != null);
+      const tempDisplay = isRange
+        ? `${mock.target_temp_low}-${mock.target_temp_high}°`
+        : (mock.temperature != null ? `${mock.temperature}°` : '—');
+      const tempClass = isRange ? 'cc-temp cc-temp-range' : 'cc-temp';
       cardEl.innerHTML = `
         <div class="card">
           <div class="card-title"><span>climate</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
           <div class="preview-climate">
             <div class="cc-header">
-              <span class="cc-name">${o.name || o.entity_id || 'Climate'}</span>
-              <div class="cc-power ${CLIMATE_MOCK.state === 'off' ? 'is-off' : ''}">${mdiSvg(MDI.power)}</div>
+              <span class="cc-name">${o.name || haFriendlyName(o.entity_id) || 'Climate'}</span>
+              <div class="cc-power ${mock.state === 'off' ? 'is-off' : ''}">${mdiSvg(MDI.power)}</div>
             </div>
             <div class="cc-temp-row">
               <div class="cc-stepper">−</div>
               <div class="cc-temp-col">
-                <div class="cc-temp">${CLIMATE_MOCK.temperature}°</div>
-                <div class="cc-current">Now ${CLIMATE_MOCK.current_temperature}°</div>
+                <div class="${tempClass}">${tempDisplay}</div>
+                <div class="cc-current">Now ${mock.current_temperature != null ? mock.current_temperature + '°' : ''}</div>
               </div>
               <div class="cc-stepper">+</div>
             </div>
-            ${hvacModes.length ? `${showCaptions ? '<div class="cc-caption">Mode</div>' : ''}${climateChipRowsHtml(hvacModes, CLIMATE_MOCK.state, hvacStyle, hvacStyle === 'icons' ? 5 : 3, climateHvacLabel, climateHvacIcon)}` : ''}
-            ${fanModes.length ? `${showCaptions ? '<div class="cc-caption">Fan</div>' : ''}${climateChipRowsHtml(fanModes, CLIMATE_MOCK.fan_mode, fanStyle, fanStyle === 'icons' ? 5 : 3, climateFanLabel, climateFanIcon)}` : ''}
-            ${swingModes.length ? `${showCaptions ? '<div class="cc-caption">Swing</div>' : ''}${climateChipRowsHtml(swingModes, CLIMATE_MOCK.swing_mode, swingStyle, swingStyle === 'icons' ? 5 : 3, climateSwingLabel, climateSwingIcon)}` : ''}
+            ${hvacModes.length ? `${showCaptions ? '<div class="cc-caption">Mode</div>' : ''}${climateChipRowsHtml(hvacModes, mock.state, hvacStyle, hvacStyle === 'icons' ? 5 : 3, climateHvacLabel, climateHvacIcon)}` : ''}
+            ${fanModes.length ? `${showCaptions ? '<div class="cc-caption">Fan</div>' : ''}${climateChipRowsHtml(fanModes, mock.fan_mode, fanStyle, fanStyle === 'icons' ? 5 : 3, climateFanLabel, climateFanIcon)}` : ''}
+            ${swingModes.length ? `${showCaptions ? '<div class="cc-caption">Swing</div>' : ''}${climateChipRowsHtml(swingModes, mock.swing_mode, swingStyle, swingStyle === 'icons' ? 5 : 3, climateSwingLabel, climateSwingIcon)}` : ''}
           </div>
-          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'climate.entity'}${usingExample ? ' · no overrides set — showing example modes (your real device\'s modes render live in the app)' : ''}</div>
+          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'climate.entity'}${haEntity(o.entity_id) ? ' · live HA data' : (usingExample ? ' · no overrides set — showing example modes (your real device\'s modes render live in the app)' : '')}</div>
         </div>`;
     } else if (card.type === 'cover') {
       const o = card.options || {};
-      const name = o.name || o.entity_id || COVER_MOCK.friendly_name;
-      const position = COVER_MOCK.current_position; // 0..100
-      const tilt = COVER_MOCK.current_tilt_position; // 0..100
-      const isOpen = position != null ? position >= 100 : COVER_MOCK.state === 'open';
-      const isClosed = position != null ? position <= 0 : COVER_MOCK.state === 'closed';
-      const stateLabel = coverPositionLabel(position, COVER_MOCK.state);
+      const mock = liveMock(o.entity_id, COVER_MOCK);
+      const name = o.name || haFriendlyName(o.entity_id) || mock.friendly_name;
+      const position = mock.current_position; // 0..100
+      const tilt = mock.current_tilt_position; // 0..100
+      const isOpen = position != null ? position >= 100 : mock.state === 'open';
+      const isClosed = position != null ? position <= 0 : mock.state === 'closed';
+      const stateLabel = coverPositionLabel(position, mock.state);
       const layout = (o.layout === 'horizontal' || o.layout === 'vertical') ? o.layout : 'default';
       // Only 2 icon variants exist (fully open / fully closed shutter) — show
       // "closed" only when truly closed (0%); anything else reads as "open"
@@ -428,7 +648,7 @@ function renderPreview() {
         <div class="card">
           <div class="card-title"><span>cover</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
           ${bodyHtml}
-          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'cover.entity'} · Layout: ${layout} · Controls: ${enabledControls.join(', ') || 'none'} · example data (${COVER_MOCK.friendly_name}, ${position}% open${ctrlTilt ? `, tilt ${tilt}%` : ''})</div>
+          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'cover.entity'} · Layout: ${layout} · Controls: ${enabledControls.join(', ') || 'none'} · ${haEntity(o.entity_id) ? 'live HA data' : 'example data'} (${mock.friendly_name}, ${position}% open${ctrlTilt ? `, tilt ${tilt}%` : ''})</div>
         </div>`;
     } else if (card.type === 'select') {
       const o = card.options || {};
@@ -490,9 +710,10 @@ function renderPreview() {
         </div>`;
     } else if (card.type === 'light') {
       const o = card.options || {};
-      const name = o.name || o.entity_id || LIGHT_MOCK.friendly_name;
-      const isOn = LIGHT_MOCK.state === 'on';
-      const brightnessPct = LIGHT_MOCK.brightness != null ? Math.round((LIGHT_MOCK.brightness / 255) * 100) : null;
+      const mock = liveMock(o.entity_id, LIGHT_MOCK);
+      const name = o.name || haFriendlyName(o.entity_id) || mock.friendly_name;
+      const isOn = mock.state === 'on';
+      const brightnessPct = mock.brightness != null ? Math.round((mock.brightness / 255) * 100) : null;
       const useLightColor = o.use_light_color === true;
       const showBrightness = o.show_brightness !== false;
       const layout = (o.layout === 'horizontal' || o.layout === 'vertical') ? o.layout : 'default';
@@ -502,7 +723,7 @@ function renderPreview() {
       // follows the light's rgb_color only when "use_light_color" is set,
       // otherwise the plain amber "on" look. This mock reports color_temp/xy
       // (no rgb_color of its own — see kelvinToPreviewRgb in mocks.js).
-      const [r, g, b] = LIGHT_MOCK.rgb_color || kelvinToPreviewRgb(LIGHT_MOCK.color_temp_kelvin);
+      const [r, g, b] = mock.rgb_color || kelvinToPreviewRgb(mock.color_temp_kelvin);
       const lightColorCss = (isOn && useLightColor) ? `rgb(${r},${g},${b})` : null;
       const iconPath = isOn ? MDI.lightbulbOn : MDI.lightbulbOff;
       const iconBg = !isOn ? 'var(--control)' : (lightColorCss ? `rgba(${r},${g},${b},0.22)` : 'var(--amber)');
@@ -512,7 +733,7 @@ function renderPreview() {
       // Mirrors LightCard.kt: if none of the 3 flags are set at all, fall
       // back to "brightness control only" so untouched configs preview
       // exactly as they always have.
-      const supportedModes = LIGHT_MOCK.supported_color_modes || [];
+      const supportedModes = mock.supported_color_modes || [];
       const supportsColor = supportedModes.some(m => ['hs', 'rgb', 'rgbw', 'rgbww', 'xy'].includes(m));
       const supportsColorTemp = supportedModes.includes('color_temp');
       const hasLightCtrlOpts = ('show_brightness_control' in o) || ('show_color_temp_control' in o) || ('show_color_control' in o);
@@ -540,7 +761,7 @@ function renderPreview() {
         </div>`;
       const colorTempSliderHtml = `
         <div class="pc-slider" style="background:linear-gradient(90deg,#FFB366,#FFF3E0,#9EC8FF)">
-          <div class="pc-slider-label" style="color:#241A00">${LIGHT_MOCK.color_temp_kelvin}K</div>
+          <div class="pc-slider-label" style="color:#241A00">${mock.color_temp_kelvin}K</div>
         </div>`;
       const colorSwatchesHtml = `
         <div class="pl-color-row">
@@ -591,18 +812,18 @@ function renderPreview() {
         <div class="card">
           <div class="card-title"><span>light</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
           ${bodyHtml}
-          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'light.entity'} · Layout: ${layout}${useLightColor ? ' · icon tinted with light colour' : ''} · Controls: ${enabledControls.join(', ') || 'none'}${collapsible ? ' (hidden while off)' : ''} · example data (${LIGHT_MOCK.friendly_name}, ${brightnessPct}%)</div>
+          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'light.entity'} · Layout: ${layout}${useLightColor ? ' · icon tinted with light colour' : ''} · Controls: ${enabledControls.join(', ') || 'none'}${collapsible ? ' (hidden while off)' : ''} · ${haEntity(o.entity_id) ? 'live HA data' : 'example data'} (${mock.friendly_name}, ${brightnessPct}%)</div>
         </div>`;
     } else if (card.type === 'media_player') {
       const o = card.options || {};
-      const mock = MEDIA_MOCK;
+      const mock = liveMock(o.entity_id, MEDIA_MOCK);
       const full = o.variant === 'full';
       const useMediaInfo = o.use_media_info !== false;
       const showVolumeLevel = o.show_volume_level === true;
       const mediaControls = (o.media_controls || 'previous,play_pause,next').split(',').map(s => s.trim()).filter(Boolean);
       const volumeControls = (o.volume_controls || 'mute,buttons').split(',').map(s => s.trim()).filter(Boolean);
 
-      const title = useMediaInfo ? (mock.media_title || o.name || mock.friendly_name) : (o.name || mock.friendly_name);
+      const title = useMediaInfo ? (mock.media_title || o.name || haFriendlyName(o.entity_id) || mock.friendly_name) : (o.name || haFriendlyName(o.entity_id) || mock.friendly_name);
       const subtitle = useMediaInfo ? (mock.media_artist || mock.app_name) : null;
       let stateLine = subtitle || mediaStateLabel(mock.state);
       if (showVolumeLevel) stateLine += ` ⸱ ${Math.round((mock.volume_level || 0) * 100)}%`;
@@ -668,7 +889,7 @@ function renderPreview() {
         <div class="card">
           <div class="card-title"><span>media_player (${full ? 'full' : 'compact'})</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
           ${bodyHtml}
-          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'media_player.entity'} · example data (${mock.friendly_name}, ${mock.state}) · long-press the compact tile in-app opens the detail dialog</div>
+          <div class="hint" style="margin-top:6px">Entity: ${o.entity_id || 'media_player.entity'} · ${haEntity(o.entity_id) ? 'live HA data' : 'example data'} (${mock.friendly_name}, ${mock.state}) · long-press the compact tile in-app opens the detail dialog</div>
         </div>`;
     } else if (card.type === 'button_grid' || card.type === 'scene_grid') {
       const isScene = card.type === 'scene_grid';
@@ -753,7 +974,7 @@ function renderPreview() {
       cardEl.className = 'card';
       cardEl.innerHTML = `
         <div class="card-title"><span>${card.type}</span><span><span class="remove" style="color:#00E5FF" onclick="editCard(${idx})">✎</span> <span class="remove" onclick="removeCard(${idx})">✕</span></span></div>
-        <div><strong>${card.options?.name || card.options?.entity_id || card.type}</strong><br>
+        <div><strong>${card.options?.name || haFriendlyName(card.options?.entity_id) || card.options?.entity_id || card.type}</strong><br>
         <small style="color:#888">${card.options?.entity_id || card.options?.remote_entity || ''}</small></div>`;
     }
     contentContainer.appendChild(cardEl);


### PR DESCRIPTION
Makes the dashboard editor preview render with live Home Assistant data instead of static mock examples.

## What's included

### Live HA entity data in the editor preview
- New `GET /ha-states` endpoint serves the running app's full entity map as JSON: `{ "connected": true, "states": { "entity_id": { "state", "friendly_name", "attributes" }, ... } }`. `connected` reflects the WebSocket state at call time; the editor falls back to the static mocks when it's false (or when the endpoint isn't reachable, e.g. the GitHub Pages copy of the editor)
- `liveMock(entityId, baseMock)` in `preview.js` overlays live state/names/attributes onto the static `*_MOCK` objects for cover, light, fan, vacuum, climate, and media_player previews. Null-safe merge — skips null attributes so they don't clobber sane defaults (e.g. `temperature: null` on a `heat_cool` climate)
- `prettyEntityName()` mimics HA's `friendly_name` fallback for cards without a configured name

### Entity ID autocomplete
- Entity ID fields in the card editor show a dropdown of matching live HA entities, filtered by domain per card type. Keyboard nav (up/down/enter/escape) and click-to-accept
- Singleton `position: fixed` dropdown with capture-phase scroll listeners (the card-edit modal scrolls internally; `window` scroll never fires), so it tracks the input correctly inside scrolling modals
- Falls back to a plain text input when `haStates` is null (no HA connection, or the editor is running on GitHub Pages)

### Climate range mode fix
- `heat_cool` climate entities use `target_temp_high`/`target_temp_low` (with `temperature: null`). Previously showed "—" for the setpoint; now shows "<low>-<high>°" both on-device and in the web preview
- Steppers shift both bounds together, preserving the deadband

## How it works

The editor's `loadDashboardFromDevice()` (in `device.js`) calls `loadHaStates()` on startup, which fetches `/ha-states` and stores the result in a global `haStates` object. Each card's preview renderer calls `liveMock(entityId, STATIC_MOCK)` to merge live attributes onto the mock, then renders with the merged data. When `haStates` is null (GitHub Pages, HA offline, or an older app build without the endpoint), all live-data features silently fall back to the static mocks + `prettyEntityName()`.

The autocomplete (`attachEntityAutocomplete()` in `preview.js`) reads from the same `haStates` object, filtering by the input's expected domain (e.g. `light.*` for a light card, `cover.*` for a cover card).

## ConfigServer changes

- `ConfigServer` constructor gains a `haClient: HaClient` parameter, giving the server read access to the live entity map and connection state
- `/ha-states` route registered alongside the existing endpoints

## Notes / scope

Self-contained against `main`. No new config fields — this is purely an editor preview enhancement and a climate display fix. The `haClient` parameter is the only API change; `MainActivity` already passes it when constructing the `ConfigServer`.

Built and verified on a HA100 (Android 8.1, MT6580).
