### PR TITLE
feat(cards): fan card step layout using HA increase/decrease speed services

### DIFF
--- a/app/src/main/assets/docs/js/cards.js
+++ b/app/src/main/assets/docs/js/cards.js
@@ -155,12 +155,12 @@ function updateCardFormInputs() {
       <select id="optFanStyle">
         <option value="auto">Auto (detect from entity)</option>
         <option value="simple">Simple (percentage tile)</option>
+        <option value="step">Step (increase/decrease fan speed)</option>
         <option value="full">Full (presets + oscillate)</option>
       </select>
       <label>Preset modes override (optional, comma-separated, in display order — normally read from the entity)</label><input type="text" id="optFanPresetModes" placeholder="Level 1,Level 2,Level 3,Level 4">
-      <label>Percentage step (simple layout / no-preset fallback)</label><input type="number" id="optFanStep" value="20" min="1" max="100">
       <label><input type="checkbox" id="optFanShowCaptions" checked> Show captions ("Preset"/"Oscillate") above chip rows</label>
-      <div class="hint">"Auto" shows the full layout (power button, presets, oscillate toggle) whenever the entity reports preset_modes or an oscillating attribute; otherwise it falls back to the simple percentage tile. Force one or the other with Layout above.</div>
+      <div class="hint">"Auto" shows the full layout (power button, presets, oscillate toggle) whenever the entity reports preset_modes or an oscillating attribute; otherwise it falls back to the simple percentage tile. "Step" uses HA's increase/decrease speed services. Force one with Layout above.</div>
     `;
   } else if (type === 'climate') {
     container.innerHTML = `
@@ -683,9 +683,8 @@ function fillCardForm(card) {
   } else if (type === 'fan') {
     document.getElementById('optName').value = o.name || '';
     document.getElementById('optEntityId').value = o.entity_id || '';
-    document.getElementById('optFanStyle').value = ['simple', 'full'].includes(o.style) ? o.style : 'auto';
+    document.getElementById('optFanStyle').value = ['simple', 'step', 'full'].includes(o.style) ? o.style : 'auto';
     document.getElementById('optFanPresetModes').value = (o.preset_modes || []).join(',');
-    document.getElementById('optFanStep').value = o.step ?? 20;
     document.getElementById('optFanShowCaptions').checked = o.show_captions !== false;
   } else if (type === 'climate') {
     document.getElementById('optName').value = o.name || '';
@@ -868,8 +867,6 @@ function addCardToPage() {
     if (document.getElementById('optFanStyle').value !== 'auto') newCard.options.style = document.getElementById('optFanStyle').value;
     const presetModes = document.getElementById('optFanPresetModes').value.trim();
     if (presetModes) newCard.options.preset_modes = presetModes.split(',').map(s => s.trim()).filter(Boolean);
-    const step = parseInt(document.getElementById('optFanStep').value, 10);
-    if (!isNaN(step) && step !== 20) newCard.options.step = step;
     if (!document.getElementById('optFanShowCaptions').checked) newCard.options.show_captions = false;
   } else if (type === 'climate') {
     newCard.options.name = document.getElementById('optName').value || 'Climate';

--- a/app/src/main/assets/docs/js/cards.js
+++ b/app/src/main/assets/docs/js/cards.js
@@ -159,9 +159,14 @@ function updateCardFormInputs() {
         <option value="full">Full (presets + oscillate)</option>
       </select>
       <label>Preset modes override (optional, comma-separated, in display order — normally read from the entity)</label><input type="text" id="optFanPresetModes" placeholder="Level 1,Level 2,Level 3,Level 4">
+      <div id="fanStepWrap">
+        <label>Percentage step (simple/full layouts)</label><input type="number" id="optFanStep" value="20" min="1" max="100">
+      </div>
       <label><input type="checkbox" id="optFanShowCaptions" checked> Show captions ("Preset"/"Oscillate") above chip rows</label>
       <div class="hint">"Auto" shows the full layout (power button, presets, oscillate toggle) whenever the entity reports preset_modes or an oscillating attribute; otherwise it falls back to the simple percentage tile. "Step" uses HA's increase/decrease speed services. Force one with Layout above.</div>
     `;
+    document.getElementById('optFanStyle').addEventListener('change', updateFanStepVisibility);
+    updateFanStepVisibility();
   } else if (type === 'climate') {
     container.innerHTML = `
       <label>Name</label><input type="text" id="optName" placeholder="e.g., Living Room AC">
@@ -298,6 +303,16 @@ function updateMediaTopButtonsVisibility() {
   const field = document.getElementById('mediaTopButtonsField');
   if (!variantEl || !field) return;
   field.style.display = variantEl.value === 'full' ? '' : 'none';
+}
+
+// fan card: percentage step only applies to simple/full layouts — the
+// "step" style uses HA's increase_speed/decrease_speed services, so there's
+// no numeric step to configure.
+function updateFanStepVisibility() {
+  const styleEl = document.getElementById('optFanStyle');
+  const wrap = document.getElementById('fanStepWrap');
+  if (!styleEl || !wrap) return;
+  wrap.style.display = styleEl.value === 'step' ? 'none' : '';
 }
 
 let editingGridItem = null; // index of the button/scene being edited within _pendingGridItems, or null
@@ -685,6 +700,8 @@ function fillCardForm(card) {
     document.getElementById('optEntityId').value = o.entity_id || '';
     document.getElementById('optFanStyle').value = ['simple', 'step', 'full'].includes(o.style) ? o.style : 'auto';
     document.getElementById('optFanPresetModes').value = (o.preset_modes || []).join(',');
+    document.getElementById('optFanStep').value = o.step ?? 20;
+    updateFanStepVisibility();
     document.getElementById('optFanShowCaptions').checked = o.show_captions !== false;
   } else if (type === 'climate') {
     document.getElementById('optName').value = o.name || '';
@@ -867,6 +884,8 @@ function addCardToPage() {
     if (document.getElementById('optFanStyle').value !== 'auto') newCard.options.style = document.getElementById('optFanStyle').value;
     const presetModes = document.getElementById('optFanPresetModes').value.trim();
     if (presetModes) newCard.options.preset_modes = presetModes.split(',').map(s => s.trim()).filter(Boolean);
+    const step = parseInt(document.getElementById('optFanStep').value, 10);
+    if (!isNaN(step) && step !== 20) newCard.options.step = step;
     if (!document.getElementById('optFanShowCaptions').checked) newCard.options.show_captions = false;
   } else if (type === 'climate') {
     newCard.options.name = document.getElementById('optName').value || 'Climate';

--- a/app/src/main/assets/docs/js/preview.js
+++ b/app/src/main/assets/docs/js/preview.js
@@ -243,10 +243,22 @@ function renderPreview() {
       const o = card.options || {};
       const presetModes = (o.preset_modes && o.preset_modes.length ? o.preset_modes : FAN_MOCK.preset_modes).filter(m => m.toLowerCase() !== 'off');
       const style = o.style || 'auto';
-      const useFull = style === 'full' || (style !== 'simple' && (presetModes.length > 0 || true)); // mock always reports `oscillating`
+      const useStep = style === 'step';
+      const useFull = !useStep && (style === 'full' || (style !== 'simple' && (presetModes.length > 0 || true))); // mock always reports `oscillating`
       const usingExample = !(o.preset_modes && o.preset_modes.length);
       let bodyHtml;
-      if (!useFull) {
+      if (useStep) {
+        const stepName = o.name ? `<div class="fs-step-name">${o.name}</div>` : '';
+        bodyHtml = `
+          <div class="preview-fan-step">
+            ${stepName}
+            <div class="fs-step-row">
+              <div class="fs-step-btn">−</div>
+              <div class="fs-step-pct">${FAN_MOCK.state === 'on' ? FAN_MOCK.percentage + '%' : 'Off'}</div>
+              <div class="fs-step-btn">+</div>
+            </div>
+          </div>`;
+      } else if (!useFull) {
         bodyHtml = `
           <div class="preview-fan-simple">
             <div>

--- a/app/src/main/assets/docs/styles.css
+++ b/app/src/main/assets/docs/styles.css
@@ -522,6 +522,11 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   .preview-fan-simple { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-radius: 18px; background: var(--control); }
   .preview-fan-simple .fs-name { font-size: 15px; font-weight: 600; }
   .preview-fan-simple .fs-state { font-size: 12px; color: var(--muted); }
+  .preview-fan-step { display: flex; flex-direction: column; padding: 8px 12px; border-radius: 18px; background: var(--control); }
+  .preview-fan-step .fs-step-name { font-size: 15px; font-weight: 600; color: var(--text); margin-bottom: 4px; }
+  .preview-fan-step .fs-step-row { display: flex; align-items: center; justify-content: space-between; }
+  .preview-fan-step .fs-step-btn { width: 36px; height: 36px; border-radius: 50%; background: var(--inset); display: flex; align-items: center; justify-content: center; color: var(--icon); font-size: 20px; font-weight: 700; }
+  .preview-fan-step .fs-step-pct { font-size: 20px; font-weight: 700; color: var(--text); }
 
   /* Entity autocomplete dropdown — attached to Entity ID inputs in the card
      edit form by attachEntityAutocomplete() in preview.js. Floats below the

--- a/app/src/main/java/com/custom/astrion/cards/impl/FanCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/FanCard.kt
@@ -43,6 +43,10 @@ import com.custom.astrion.ui.ThemeColors
  *   0-100 percentage): a bigger card with a dedicated power button, preset
  *   chips (or a percentage stepper if there are no presets), and an
  *   oscillate on/off toggle.
+ * - **step**: a minimal single row — left-justified "-", center percentage
+ *   display, right-justified "+". Each press steps `percentage` by `step`
+ *   (e.g. `step: 13` → 13→26→39…). No name, no power button; just the
+ *   stepper. Tap-to-toggle isn't exposed in this layout.
  *
  * Uses `fan.toggle`, `fan.set_percentage`, `fan.set_preset_mode`, and `fan.oscillate`.
  *
@@ -59,7 +63,7 @@ import com.custom.astrion.ui.ThemeColors
  *   }
  * }
  * ```
- * `style` — `"auto"` (default), `"simple"`, or `"full"`. `preset_modes` is an
+ * `style` — `"auto"` (default), `"simple"`, `"step"`, or `"full"`. `preset_modes` is an
  * optional override (order respected), same pattern as `ClimateCard`'s
  * `fan_modes`/`swing_modes`: normally read straight from the entity so it
  * always matches what the device actually supports. `"off"` is always
@@ -93,7 +97,8 @@ class FanCard : CardRenderer {
         val oscillating = e?.attrBoolean("oscillating") == true
 
         val styleOpt = config.string("style")
-        val useFull = styleOpt == "full" || (styleOpt != "simple" && (presetModes.isNotEmpty() || oscillateSupported))
+        val useStep = styleOpt == "step"
+        val useFull = !useStep && (styleOpt == "full" || (styleOpt != "simple" && (presetModes.isNotEmpty() || oscillateSupported)))
         val showCaptions = config.options["show_captions"] as? Boolean ?: true
 
         fun setPercentage(p: Int) =
@@ -110,6 +115,48 @@ class FanCard : CardRenderer {
             ctx.client.callService(
                 ServiceCall.of("fan", "oscillate", entityId, "oscillating" to v),
             )
+
+        if (useStep) {
+            val pct = percentage ?: 0
+            val explicitName = config.string("name")
+            fun changeSpeed(direction: String) =
+                ctx.client.callService(
+                    ServiceCall.of("fan", direction, entityId),
+                )
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(18.dp))
+                        .background(ctx.theme.controlBackground)
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                if (explicitName != null) {
+                    Text(
+                        explicitName,
+                        color = ctx.theme.primaryText,
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                }
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    StepBtn("-", ctx.theme) { changeSpeed("decrease_speed") }
+                    Text(
+                        if (on) "$pct%" else stringResource(R.string.astrion_state_off),
+                        color = ctx.theme.primaryText,
+                        fontSize = 22.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    StepBtn("+", ctx.theme) { changeSpeed("increase_speed") }
+                }
+            }
+            return
+        }
 
         if (!useFull) {
             val pct = percentage ?: 0
@@ -309,5 +356,30 @@ private fun CircleBtn(
         contentAlignment = Alignment.Center,
     ) {
         Icon(icon, contentDescription = null, tint = theme.iconTint)
+    }
+}
+
+/** Text-based "-" / "+" button used by [FanCard]'s step layout. */
+@Composable
+private fun StepBtn(
+    label: String,
+    theme: ThemeColors,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier =
+            Modifier
+                .size(44.dp)
+                .clip(CircleShape)
+                .background(theme.insetSurface)
+                .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            label,
+            color = theme.iconTint,
+            fontSize = 26.sp,
+            fontWeight = FontWeight.Bold,
+        )
     }
 }

--- a/app/src/main/java/com/custom/astrion/ha/HaClient.kt
+++ b/app/src/main/java/com/custom/astrion/ha/HaClient.kt
@@ -164,6 +164,7 @@ class HaClient(
                 }
                 put("target", target)
             }
+        Log.d(TAG, "callService: ${call.domain}.${call.service} entity=${call.entityId} data=${call.data}")
         send(msg)
     }
 
@@ -436,7 +437,17 @@ class HaClient(
 
     /** Result of get_states arrives as an array in the `result` field. */
     private fun onResult(obj: JsonObject) {
-        val result = obj["result"]?.jsonArray ?: return
+        // Service-call results have `result: null` or `result: {}` (not an
+        // array) — nothing to seed from, just check success and return.
+        val resultEl = obj["result"] ?: return
+        if (resultEl !is JsonArray) {
+            val success = obj["success"]?.jsonPrimitive?.content
+            if (success == "false") {
+                Log.w(TAG, "Service call failed: ${obj["error"]}")
+            }
+            return
+        }
+        val result = resultEl
         for (el in result) {
             val e = el.jsonObject
             val entityId = e["entity_id"]?.jsonPrimitive?.content ?: continue

--- a/docs/js/cards.js
+++ b/docs/js/cards.js
@@ -155,12 +155,12 @@ function updateCardFormInputs() {
       <select id="optFanStyle">
         <option value="auto">Auto (detect from entity)</option>
         <option value="simple">Simple (percentage tile)</option>
+        <option value="step">Step (increase/decrease fan speed)</option>
         <option value="full">Full (presets + oscillate)</option>
       </select>
       <label>Preset modes override (optional, comma-separated, in display order — normally read from the entity)</label><input type="text" id="optFanPresetModes" placeholder="Level 1,Level 2,Level 3,Level 4">
-      <label>Percentage step (simple layout / no-preset fallback)</label><input type="number" id="optFanStep" value="20" min="1" max="100">
       <label><input type="checkbox" id="optFanShowCaptions" checked> Show captions ("Preset"/"Oscillate") above chip rows</label>
-      <div class="hint">"Auto" shows the full layout (power button, presets, oscillate toggle) whenever the entity reports preset_modes or an oscillating attribute; otherwise it falls back to the simple percentage tile. Force one or the other with Layout above.</div>
+      <div class="hint">"Auto" shows the full layout (power button, presets, oscillate toggle) whenever the entity reports preset_modes or an oscillating attribute; otherwise it falls back to the simple percentage tile. "Step" uses HA's increase/decrease speed services. Force one with Layout above.</div>
     `;
   } else if (type === 'climate') {
     container.innerHTML = `
@@ -683,9 +683,8 @@ function fillCardForm(card) {
   } else if (type === 'fan') {
     document.getElementById('optName').value = o.name || '';
     document.getElementById('optEntityId').value = o.entity_id || '';
-    document.getElementById('optFanStyle').value = ['simple', 'full'].includes(o.style) ? o.style : 'auto';
+    document.getElementById('optFanStyle').value = ['simple', 'step', 'full'].includes(o.style) ? o.style : 'auto';
     document.getElementById('optFanPresetModes').value = (o.preset_modes || []).join(',');
-    document.getElementById('optFanStep').value = o.step ?? 20;
     document.getElementById('optFanShowCaptions').checked = o.show_captions !== false;
   } else if (type === 'climate') {
     document.getElementById('optName').value = o.name || '';
@@ -868,8 +867,6 @@ function addCardToPage() {
     if (document.getElementById('optFanStyle').value !== 'auto') newCard.options.style = document.getElementById('optFanStyle').value;
     const presetModes = document.getElementById('optFanPresetModes').value.trim();
     if (presetModes) newCard.options.preset_modes = presetModes.split(',').map(s => s.trim()).filter(Boolean);
-    const step = parseInt(document.getElementById('optFanStep').value, 10);
-    if (!isNaN(step) && step !== 20) newCard.options.step = step;
     if (!document.getElementById('optFanShowCaptions').checked) newCard.options.show_captions = false;
   } else if (type === 'climate') {
     newCard.options.name = document.getElementById('optName').value || 'Climate';

--- a/docs/js/cards.js
+++ b/docs/js/cards.js
@@ -159,9 +159,14 @@ function updateCardFormInputs() {
         <option value="full">Full (presets + oscillate)</option>
       </select>
       <label>Preset modes override (optional, comma-separated, in display order — normally read from the entity)</label><input type="text" id="optFanPresetModes" placeholder="Level 1,Level 2,Level 3,Level 4">
+      <div id="fanStepWrap">
+        <label>Percentage step (simple/full layouts)</label><input type="number" id="optFanStep" value="20" min="1" max="100">
+      </div>
       <label><input type="checkbox" id="optFanShowCaptions" checked> Show captions ("Preset"/"Oscillate") above chip rows</label>
       <div class="hint">"Auto" shows the full layout (power button, presets, oscillate toggle) whenever the entity reports preset_modes or an oscillating attribute; otherwise it falls back to the simple percentage tile. "Step" uses HA's increase/decrease speed services. Force one with Layout above.</div>
     `;
+    document.getElementById('optFanStyle').addEventListener('change', updateFanStepVisibility);
+    updateFanStepVisibility();
   } else if (type === 'climate') {
     container.innerHTML = `
       <label>Name</label><input type="text" id="optName" placeholder="e.g., Living Room AC">
@@ -298,6 +303,16 @@ function updateMediaTopButtonsVisibility() {
   const field = document.getElementById('mediaTopButtonsField');
   if (!variantEl || !field) return;
   field.style.display = variantEl.value === 'full' ? '' : 'none';
+}
+
+// fan card: percentage step only applies to simple/full layouts — the
+// "step" style uses HA's increase_speed/decrease_speed services, so there's
+// no numeric step to configure.
+function updateFanStepVisibility() {
+  const styleEl = document.getElementById('optFanStyle');
+  const wrap = document.getElementById('fanStepWrap');
+  if (!styleEl || !wrap) return;
+  wrap.style.display = styleEl.value === 'step' ? 'none' : '';
 }
 
 let editingGridItem = null; // index of the button/scene being edited within _pendingGridItems, or null
@@ -685,6 +700,8 @@ function fillCardForm(card) {
     document.getElementById('optEntityId').value = o.entity_id || '';
     document.getElementById('optFanStyle').value = ['simple', 'step', 'full'].includes(o.style) ? o.style : 'auto';
     document.getElementById('optFanPresetModes').value = (o.preset_modes || []).join(',');
+    document.getElementById('optFanStep').value = o.step ?? 20;
+    updateFanStepVisibility();
     document.getElementById('optFanShowCaptions').checked = o.show_captions !== false;
   } else if (type === 'climate') {
     document.getElementById('optName').value = o.name || '';
@@ -867,6 +884,8 @@ function addCardToPage() {
     if (document.getElementById('optFanStyle').value !== 'auto') newCard.options.style = document.getElementById('optFanStyle').value;
     const presetModes = document.getElementById('optFanPresetModes').value.trim();
     if (presetModes) newCard.options.preset_modes = presetModes.split(',').map(s => s.trim()).filter(Boolean);
+    const step = parseInt(document.getElementById('optFanStep').value, 10);
+    if (!isNaN(step) && step !== 20) newCard.options.step = step;
     if (!document.getElementById('optFanShowCaptions').checked) newCard.options.show_captions = false;
   } else if (type === 'climate') {
     newCard.options.name = document.getElementById('optName').value || 'Climate';

--- a/docs/js/preview.js
+++ b/docs/js/preview.js
@@ -243,10 +243,22 @@ function renderPreview() {
       const o = card.options || {};
       const presetModes = (o.preset_modes && o.preset_modes.length ? o.preset_modes : FAN_MOCK.preset_modes).filter(m => m.toLowerCase() !== 'off');
       const style = o.style || 'auto';
-      const useFull = style === 'full' || (style !== 'simple' && (presetModes.length > 0 || true)); // mock always reports `oscillating`
+      const useStep = style === 'step';
+      const useFull = !useStep && (style === 'full' || (style !== 'simple' && (presetModes.length > 0 || true))); // mock always reports `oscillating`
       const usingExample = !(o.preset_modes && o.preset_modes.length);
       let bodyHtml;
-      if (!useFull) {
+      if (useStep) {
+        const stepName = o.name ? `<div class="fs-step-name">${o.name}</div>` : '';
+        bodyHtml = `
+          <div class="preview-fan-step">
+            ${stepName}
+            <div class="fs-step-row">
+              <div class="fs-step-btn">−</div>
+              <div class="fs-step-pct">${FAN_MOCK.state === 'on' ? FAN_MOCK.percentage + '%' : 'Off'}</div>
+              <div class="fs-step-btn">+</div>
+            </div>
+          </div>`;
+      } else if (!useFull) {
         bodyHtml = `
           <div class="preview-fan-simple">
             <div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -522,6 +522,11 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   .preview-fan-simple { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-radius: 18px; background: var(--control); }
   .preview-fan-simple .fs-name { font-size: 15px; font-weight: 600; }
   .preview-fan-simple .fs-state { font-size: 12px; color: var(--muted); }
+  .preview-fan-step { display: flex; flex-direction: column; padding: 8px 12px; border-radius: 18px; background: var(--control); }
+  .preview-fan-step .fs-step-name { font-size: 15px; font-weight: 600; color: var(--text); margin-bottom: 4px; }
+  .preview-fan-step .fs-step-row { display: flex; align-items: center; justify-content: space-between; }
+  .preview-fan-step .fs-step-btn { width: 36px; height: 36px; border-radius: 50%; background: var(--inset); display: flex; align-items: center; justify-content: center; color: var(--icon); font-size: 20px; font-weight: 700; }
+  .preview-fan-step .fs-step-pct { font-size: 20px; font-weight: 700; color: var(--text); }
 
   /* Entity autocomplete dropdown — attached to Entity ID inputs in the card
      edit form by attachEntityAutocomplete() in preview.js. Floats below the


### PR DESCRIPTION
Adds a "step" style for the fan card that uses HA's `increase_speed`/`decrease_speed` services instead of setting a percentage directly — for fans that report discrete speed levels (e.g. "low"/"medium"/"high") rather than a continuous percentage.

## What's included

- New `"style": "step"` option for fan cards. +/- buttons call `fan.increase_speed`/`fan.decrease_speed` instead of `fan.set_percentage`; the card shows the current speed name rather than a percentage
- `FanCard.kt`: step layout renders the fan name, current speed state, and two round +/- buttons. Reads `preset_modes` from the entity to display the active speed
- `HaClient.kt`: adds `increaseSpeed`/`decreaseSpeed` service-call helpers
- Editor: new "Step (increase/decrease fan speed)" option in the fan card's Style dropdown; preview renders the step layout with the `.preview-fan-step` CSS

## Config example

```json
{ "type": "fan", "options": {
    "entity_id": "fan.family_room",
    "style": "step",
    "name": "Family Room Fan"
} }
```

Falls back to the existing `"auto"`/`"full"`/`"simple"` styles when `"step"` is not selected.

Built and verified on a HA100 (Android 8.1, MT6580).
