### PR TITLE
docs: add Getting Started guide

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -6,14 +6,39 @@ It is intended for users starting from the stock Astrion software.
 
 > **What this guide covers**
 >
-> - enabling Developer options and USB debugging
-> - installing Astrion Custom Dashboard with ADB
-> - selecting Astrion Custom as the launcher
-> - granting the required Android permissions
-> - connecting the remote to Home Assistant
-> - creating and uploading your first `dashboard.json`
-> - updating the app later without ADB
-> - recovering or returning to the stock launcher
+> - Enabling Developer options and USB debugging
+> - Installing Astrion Custom Dashboard with ADB
+> - Selecting Astrion Custom as the launcher
+> - Granting the required Android permissions
+> - Connecting the remote to Home Assistant
+> - Creating and uploading your first `dashboard.json`
+> - Updating the app later without ADB
+> - Recovering or returning to the stock launcher
+
+## Table of contents
+
+1. [Before you start](#1-before-you-start)
+2. [Install Android Platform Tools](#2-install-android-platform-tools)
+3. [Enable Developer options on the Astrion](#3-enable-developer-options-on-the-astrion)
+4. [Connect the remote with ADB](#4-connect-the-remote-with-adb)
+5. [Install Astrion Custom Dashboard](#5-install-astrion-custom-dashboard)
+6. [Restart the Astrion](#6-restart-the-astrion)
+7. [Select Astrion Custom as the launcher](#7-select-astrion-custom-as-the-launcher)
+8. [Grant storage access](#8-grant-storage-access)
+9. [Allow Astrion Custom to modify system settings](#9-allow-astrion-custom-to-modify-system-settings)
+10. [Find the remote IP address](#10-find-the-remote-ip-address)
+11. [Connect Home Assistant](#11-connect-home-assistant)
+12. [Check the Home Assistant connection](#12-check-the-home-assistant-connection)
+13. [Create your first dashboard](#13-create-your-first-dashboard)
+14. [Upload dashboard.json to the Astrion](#14-upload-dashboardjson-to-the-astrion)
+15. [Back up the current dashboard](#15-back-up-the-current-dashboard)
+16. [Upload custom icons](#16-upload-custom-icons)
+17. [Physical buttons](#17-physical-buttons)
+18. [Updating Astrion Custom Dashboard](#18-updating-astrion-custom-dashboard)
+19. [Returning to the stock Astrion launcher](#19-returning-to-the-stock-astrion-launcher)
+20. [Troubleshooting](#20-troubleshooting)
+21. [Recommended first setup workflow](#21-recommended-first-setup-workflow)
+22. [Useful links](#22-useful-links)
 
 ---
 
@@ -21,13 +46,13 @@ It is intended for users starting from the stock Astrion software.
 
 You will need:
 
-- a Sanytron Astrion HA100 connected to Wi-Fi
-- a computer on the same network as the remote
-- a USB cable for the initial installation
+- A Sanytron Astrion HA100 connected to Wi-Fi
+- A computer on the same network as the remote
+- A USB cable for the initial installation
 - Android Platform Tools (`adb`) installed on your computer
-- the latest Astrion Custom Dashboard APK
-- the URL of your Home Assistant instance
-- a Home Assistant Long-Lived Access Token
+- The latest Astrion Custom Dashboard APK
+- The URL of your Home Assistant instance
+- A Home Assistant Long-Lived Access Token
 
 You only need ADB for the initial installation and recovery. Once Astrion Custom Dashboard is running, normal configuration and updates can be done from its built-in web interface.
 
@@ -35,7 +60,7 @@ You only need ADB for the initial installation and recovery. Once Astrion Custom
 
 Download the latest release from:
 
-https://github.com/dckiller51/astrion-custom-dashboard/releases
+<https://github.com/dckiller51/astrion-custom-dashboard/releases>
 
 Save the APK somewhere easy to access from your terminal.
 
@@ -45,7 +70,7 @@ Save the APK somewhere easy to access from your terminal.
 
 If `adb` is not already installed, download **Android SDK Platform Tools** from Google:
 
-https://developer.android.com/tools/releases/platform-tools
+<https://developer.android.com/tools/releases/platform-tools>
 
 Extract the archive.
 
@@ -63,13 +88,13 @@ Verify that ADB works:
 .\adb.exe version
 ```
 
-On macOS or Linux, use:
+### macOS / Linux
 
 ```bash
 ./adb version
 ```
 
-or, if `adb` is already in your PATH:
+or, if `adb` is already in your `PATH`:
 
 ```bash
 adb version
@@ -113,9 +138,7 @@ Once the USB cable is connected, run:
 adb devices
 ```
 
-The first time, the remote should show a USB debugging authorization dialog. Approve it.
-
-Then run again:
+The first time, the remote should show a USB debugging authorization dialog. Approve it, then run the command again:
 
 ```bash
 adb devices
@@ -170,9 +193,7 @@ Success
 
 ## 6. Restart the Astrion
 
-After installation, **fully reboot the remote**.
-
-Do not only close and reopen the app.
+After installation, **fully reboot the remote** — simply closing and reopening the app is not enough.
 
 A full reboot is important because some permissions and the Android launcher registration only take full effect after the device restarts.
 
@@ -182,9 +203,7 @@ A full reboot is important because some permissions and the Android launcher reg
 
 After reboot, Android should ask which Home / launcher application to use.
 
-Select:
-
-**Astrion Custom**
+Select **Astrion Custom**.
 
 If Android offers the choice between **Just once** and **Always**, choose **Always** if you want Astrion Custom Dashboard to be the normal remote interface.
 
@@ -211,12 +230,11 @@ The dashboard configuration and custom icons are stored there.
 
 From the Astrion Custom dashboard:
 
-1. Swipe down from the top of the screen.
-2. The Astrion Custom **Settings** panel opens.
-3. Above the brightness slider, tap **Allow modification**.
-4. Android opens the system permission screen.
-5. Select **Astrion Custom** and allow modification of system settings.
-6. Return to Astrion Custom.
+1. Swipe down from the top of the screen — the Astrion Custom **Settings** panel opens.
+2. Above the brightness slider, tap **Allow modification**.
+3. Android opens the system permission screen.
+4. Select **Astrion Custom** and allow modification of system settings.
+5. Return to Astrion Custom.
 
 This permission is used for features such as display brightness control.
 
@@ -224,17 +242,13 @@ This permission is used for features such as display brightness control.
 
 ## 10. Find the remote IP address
 
-The local configuration server runs directly on the remote.
-
-Its address is:
+The local configuration server runs directly on the remote, at:
 
 ```text
 http://<remote-ip>:8080
 ```
 
-The current address is shown in the Astrion Custom Settings panel.
-
-For example:
+The current address is shown in the Astrion Custom Settings panel, for example:
 
 ```text
 http://192.168.1.50:8080
@@ -254,9 +268,9 @@ http://<remote-ip>:8080
 
 Enter:
 
-- your **Home Assistant URL**
-- your **Home Assistant Long-Lived Access Token**
-- optional Harmony Hub settings, if you use Harmony
+- Your **Home Assistant URL**
+- Your **Home Assistant Long-Lived Access Token**
+- Optional Harmony Hub settings, if you use Harmony
 
 Example local Home Assistant URL:
 
@@ -280,25 +294,21 @@ Copy the token immediately and paste it into the Astrion configuration page.
 
 > Treat this token like a password. Do not publish it or place it in `dashboard.json`.
 
-Save the connection settings.
-
-Astrion Custom restarts automatically so it can reconnect using the new settings.
+Save the connection settings. Astrion Custom restarts automatically so it can reconnect using the new settings.
 
 ---
 
 ## 12. Check the Home Assistant connection
 
-Swipe down from the top of the Astrion screen to open the Settings panel.
-
-Check the Home Assistant connection status.
+Swipe down from the top of the Astrion screen to open the Settings panel, and check the Home Assistant connection status.
 
 If it is not connected, verify:
 
-- the Home Assistant URL
-- the token
-- that the Astrion can reach Home Assistant over the network
-- that HTTP/HTTPS is correct
-- that DNS works if you used a hostname instead of an IP address
+- The Home Assistant URL
+- The token
+- That the Astrion can reach Home Assistant over the network
+- That HTTP/HTTPS is correct
+- That DNS works, if you used a hostname instead of an IP address
 
 For the first test, using a local Home Assistant IP address can make troubleshooting easier.
 
@@ -308,50 +318,30 @@ For the first test, using a local Home Assistant IP address can make troubleshoo
 
 You can build `dashboard.json` manually, but the easiest starting point is the online editor:
 
-https://dckiller51.github.io/astrion-custom-dashboard/
+<https://dckiller51.github.io/astrion-custom-dashboard/>
 
-The editor lets you create pages, cards and hotkeys without writing the whole JSON by hand.
+The editor lets you create pages, cards, and hotkeys without writing the whole JSON by hand.
 
-For a first test, keep the dashboard simple. A good first dashboard is one page with one Home Assistant entity, for example a light, media player or switch.
+For a first test, keep the dashboard simple. A good first dashboard is one page with one Home Assistant entity — for example a light, media player, or switch.
 
 This makes it easy to confirm that the Home Assistant connection and dashboard loading both work before building a larger remote configuration.
 
-When finished, export/download the generated:
-
-```text
-dashboard.json
-```
+When finished, export/download the generated `dashboard.json`.
 
 ---
 
 ## 14. Upload `dashboard.json` to the Astrion
 
-Return to:
+Return to `http://<remote-ip>:8080` and upload your new `dashboard.json`.
 
-```text
-http://<remote-ip>:8080
-```
+The dashboard reloads without requiring a new APK installation. This is the normal workflow when editing the remote:
 
-Upload your new:
-
-```text
-dashboard.json
-```
-
-The dashboard reloads without requiring a new APK installation.
-
-This is the normal workflow when editing the remote:
-
-```text
-Dashboard Editor
-        ↓
-dashboard.json
-        ↓
-Astrion :8080
-        ↓
-Upload
-        ↓
-Dashboard reloads
+```mermaid
+flowchart LR
+    A[Dashboard Editor] --> B[dashboard.json]
+    B --> C["Astrion :8080"]
+    C --> D[Upload]
+    D --> E[Dashboard reloads]
 ```
 
 No ADB is required.
@@ -382,17 +372,7 @@ Custom icons are stored in:
 /sdcard/astrion/icons/
 ```
 
-You do not need ADB to add them.
-
-Use the local Astrion configuration page at:
-
-```text
-http://<remote-ip>:8080
-```
-
-to upload PNG icons.
-
-Then reference those icons from your dashboard configuration.
+You do not need ADB to add them — use the local Astrion configuration page at `http://<remote-ip>:8080` to upload PNG icons, then reference those icons from your dashboard configuration.
 
 ---
 
@@ -402,12 +382,12 @@ Astrion Custom can map the HA100 physical buttons through dashboard hotkeys.
 
 Typical uses include:
 
-- page navigation
+- Page navigation
 - Back / Home
-- media transport
-- volume actions
-- application-specific commands
-- quick Home Assistant actions
+- Media transport
+- Volume actions
+- Application-specific commands
+- Quick Home Assistant actions
 
 It is usually easiest to first make the touchscreen dashboard work correctly, then configure physical-key behavior.
 
@@ -417,21 +397,11 @@ It is usually easiest to first make the touchscreen dashboard work correctly, th
 
 After the first installation, ADB is normally no longer needed for application updates.
 
-Open:
-
-```text
-http://<remote-ip>:8080
-```
-
-and use the update function to check GitHub Releases.
-
-When a newer release is available, the remote can download the APK and launch the Android installer.
+Open `http://<remote-ip>:8080` and use the update function to check GitHub Releases. When a newer release is available, the remote can download the APK and launch the Android installer.
 
 ### First update only
 
-Android may ask you to allow **Install unknown apps** for Astrion Custom.
-
-Grant the permission, return to the configuration page, and start the update again.
+Android may ask you to allow **Install unknown apps** for Astrion Custom. Grant the permission, return to the configuration page, and start the update again.
 
 After that, future updates normally require only a few taps.
 
@@ -456,17 +426,15 @@ The remote will fall back to the original **HaRemote** launcher.
 Check:
 
 - USB debugging is enabled
-- the USB cable supports data, not only charging
-- the remote is unlocked
-- the USB debugging authorization dialog has been accepted
+- The USB cable supports data, not only charging
+- The remote is unlocked
+- The USB debugging authorization dialog has been accepted
 
 Then reconnect the cable and run `adb devices` again.
 
 ### `adb devices` shows `unauthorized`
 
-Approve the USB debugging prompt on the Astrion and retry.
-
-If necessary:
+Approve the USB debugging prompt on the Astrion and retry. If necessary:
 
 ```bash
 adb kill-server
@@ -488,21 +456,15 @@ Then install the new APK.
 
 ### Android did not ask which launcher to use
 
-Reboot the remote once more.
-
-If Android still opens another launcher, open Android Settings and check the default Home application settings, then select **Astrion Custom**.
+Reboot the remote once more. If Android still opens another launcher, open Android Settings, check the default Home application settings, and select **Astrion Custom**.
 
 Menu names can vary by firmware.
 
 ### Home Assistant stays disconnected
 
-Check the URL and token first.
+Check the URL and token first, and confirm that the remote can reach Home Assistant from the same network.
 
-Also confirm that the remote can reach Home Assistant from the same network.
-
-If you are using a hostname, try the local IP address temporarily.
-
-For example:
+If you are using a hostname, try the local IP address temporarily, for example:
 
 ```text
 http://192.168.1.10:8123
@@ -512,9 +474,7 @@ If the IP works but the hostname does not, the problem is likely network/DNS rel
 
 ### Dashboard does not load after uploading JSON
 
-Restore the last known working `dashboard.json`.
-
-The online editor is the safest way to generate a valid starting configuration.
+Restore the last known working `dashboard.json`. The online editor is the safest way to generate a valid starting configuration.
 
 When making larger changes, save working versions frequently.
 
@@ -524,7 +484,6 @@ When making larger changes, save working versions frequently.
 
 For a new remote, the safest sequence is:
 
-```text
 1. Install Astrion Custom
 2. Reboot
 3. Select Astrion Custom launcher
@@ -535,11 +494,8 @@ For a new remote, the safest sequence is:
 8. Add more pages/cards
 9. Configure physical buttons
 10. Build Activities and advanced AV logic
-```
 
-Do not start by recreating your entire universal remote configuration.
-
-First confirm that the basic path works:
+Do not start by recreating your entire universal remote configuration. First confirm that the basic path works:
 
 ```text
 Astrion → Home Assistant → device
@@ -551,25 +507,11 @@ Then add complexity step by step.
 
 ## 22. Useful links
 
-Project:
-
-https://github.com/dckiller51/astrion-custom-dashboard
-
-Latest releases:
-
-https://github.com/dckiller51/astrion-custom-dashboard/releases
-
-Online dashboard editor:
-
-https://dckiller51.github.io/astrion-custom-dashboard/
-
-Android Platform Tools:
-
-https://developer.android.com/tools/releases/platform-tools
-
-Home Assistant:
-
-https://www.home-assistant.io/
+- Project: <https://github.com/dckiller51/astrion-custom-dashboard>
+- Latest releases: <https://github.com/dckiller51/astrion-custom-dashboard/releases>
+- Online dashboard editor: <https://dckiller51.github.io/astrion-custom-dashboard/>
+- Android Platform Tools: <https://developer.android.com/tools/releases/platform-tools>
+- Home Assistant: <https://www.home-assistant.io/>
 
 ---
 
@@ -577,14 +519,14 @@ https://www.home-assistant.io/
 
 Once the first dashboard is working, you can continue with:
 
-- multiple pages
+- Multiple pages
 - Home Assistant cards
-- media-player controls
-- physical hotkeys
-- custom icons
+- Media-player controls
+- Physical hotkeys
+- Custom icons
 - Activities
-- camera cards
-- vacuum cards
+- Camera cards
+- Vacuum cards
 - Harmony integration, if needed
 
 At that point, the local `:8080` configuration page and the online dashboard editor should be enough for normal day-to-day maintenance without ADB.


### PR DESCRIPTION
First-time setup walkthrough for a Sanytron Astrion HA100, from
enabling ADB through connecting Home Assistant and loading the first
dashboard.json, plus troubleshooting and update instructions.