### PR TITLE
feat: local beta channel via rolling dev-latest release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ dashboard.json
 # ==============================================================================
 # Local output recordings / media files
 recordings/
+push-beta.ps1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,18 @@
 All notable changes to this project are documented here.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.0.2] - 2026-08-xx
+## [1.0.2] - 2026-08-23
 
 ### Added
 
-- **Bêta locale (`dev-latest`).** New `push-beta.ps1` script publishes the current debug build straight from a local Android Studio build to a rolling GitHub pre-release (`dev-latest`), alongside pushing `dev` — no CI involved, avoids the debug-keystore instability a fresh CI runner would introduce between builds. `app/build.gradle.kts`'s `debug` build type now applies `applicationIdSuffix = ".debug"` and `versionNameSuffix = "-beta"`, so the beta installs as a separate app (`com.custom.astrion.debug`) alongside the official release — no signature conflict, no need to uninstall either one to test the other. New toggle switch in the web editor (`docs/index.html`, both on GitHub Pages and the device's own `/builder/`) shows the latest beta version and a direct APK download link, fetched live from the `dev-latest` release via the GitHub API.
+- **Bêta locale (`dev-latest`).** New `push-beta.ps1` script publishes the current debug build straight from a local Android Studio build to a rolling GitHub pre-release (`dev-latest`), alongside pushing `dev` — no CI involved, avoids the debug-keystore instability a fresh CI runner would introduce between builds. `app/build.gradle.kts`'s `debug` build type now applies `applicationIdSuffix = ".debug"` and `versionNameSuffix = "-beta"`, so the beta installs as a separate app (`com.custom.astrion.debug`) alongside the official release — no signature conflict, no need to uninstall either one to test the other. New toggle switch in the web editor (`docs/index.html`, both on GitHub Pages and the device's own `/builder/`) shows both the current official release and, when switched on, the latest beta version, each with a direct APK download link fetched live from GitHub.
+- **In-app update indicator.** `SettingsMenu` now checks GitHub Releases each time the Settings panel is opened and shows a tappable "Update available" row when a newer official build exists — downloads and launches the system installer directly, no browser needed. Always compares against `/releases/latest` (never pre-releases), so this only ever notifies about official releases, on both official and beta installs.
 
 ### Fixed
 
 - **Hotkey `openOverlay` / `openCurrentActivityRoom` silently ignored.** `DashboardLoader.parseHotkey()` never read these two fields from `dashboard.json`, so any hotkey configured with `openOverlay: "settings"`, `openOverlay: "activities"`, or `openCurrentActivityRoom: "<room>"` loaded with both fields `null` — the physical button did nothing, neither opening the overlay nor jumping to the active Activity's page, even though the web editor generated valid JSON for both. `encodeHotkeys()` had the same gap on the write side. Both fields are now parsed and re-encoded like every other `HotkeyConfig` field.
+- **"Hotkeys active on this page" badge showed nothing for `openOverlay`/`openCurrentActivityRoom` hotkeys.** `preview.js`'s `renderPreview()` used its own local `describe()`, never updated for these two actions, instead of `hotkeys.js`'s `describeHotkey()`. The JSON was already correct — only the badge's text was blank.
+- **`UpdateChecker.isNewer()` false-positive on beta builds.** The `-beta` suffix added by `versionNameSuffix` broke the numeric version comparison (`"1.0.3-beta"` → the `3` was silently dropped, comparing as `1.0` instead of `1.0.3`), causing the update checker to report "update available" almost constantly on beta installs even when already up to date or ahead. Now strips any `-suffix` before comparing.
 
 ## [1.0.0] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 All notable changes to this project are documented here.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.0.1] - 2026-08-xx
+## [1.0.2] - 2026-08-xx
+
+### Added
+
+- **Bêta locale (`dev-latest`).** New `push-beta.ps1` script publishes the current debug build straight from a local Android Studio build to a rolling GitHub pre-release (`dev-latest`), alongside pushing `dev` — no CI involved, avoids the debug-keystore instability a fresh CI runner would introduce between builds. `app/build.gradle.kts`'s `debug` build type now applies `applicationIdSuffix = ".debug"` and `versionNameSuffix = "-beta"`, so the beta installs as a separate app (`com.custom.astrion.debug`) alongside the official release — no signature conflict, no need to uninstall either one to test the other. New toggle switch in the web editor (`docs/index.html`, both on GitHub Pages and the device's own `/builder/`) shows the latest beta version and a direct APK download link, fetched live from the `dev-latest` release via the GitHub API.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 <!-- markdownlint-disable-next-line MD033 -->
+# <img src="docs/app-icon.svg" width="48" align="center" alt="Astrion Custom Icon"> Astrion Custom Dashboard
+
+<!-- markdownlint-disable-next-line MD033 -->
 <p align="center">
+  <!-- markdownlint-disable-next-line MD033 -->
   <img src="docs/banner_astrion_custom_dashboard.png" alt="Astrion Custom Dashboard Banner">
 </p>
-
-# <img src="docs/app-icon.svg" width="48" align="center" alt="Astrion Custom Icon"> Astrion Custom Dashboard
 
 [![GH-release](https://img.shields.io/github/v/release/dckiller51/astrion-custom-dashboard.svg?style=flat-square)](https://github.com/dckiller51/astrion-custom-dashboard/releases)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-Buy_me_a_coffee-F16061?style=flat-square&logo=ko-fi&logoColor=white)](https://ko-fi.com/dckiller)
@@ -40,6 +42,12 @@ Building `dashboard.json` by hand is optional — the [**online dashboard editor
 ### Updates
 
 The same local page can check this repository's [GitHub Releases](https://github.com/dckiller51/astrion-custom-dashboard/releases) for a newer build and download + launch the system installer for it — no adb required for updates either. Android requires manually approving "install unknown apps" for Astrion Custom the first time (the page will prompt for it and tell you to try again once granted); after that, updating is just two taps.
+
+### Beta builds
+
+For testing fixes before they land in an official release, pushes to `dev` are also published as a rolling **pre-release** (tag `dev-latest`, overwritten by each new push — never picked up by the updater above, which explicitly skips pre-releases). Grab it from the [**online dashboard editor**](https://dckiller51.github.io/astrion-custom-dashboard/): flip the "Version bêta (dev)" switch near the top to reveal the current beta version and a direct APK download link.
+
+The beta installs as a separate app (`com.custom.astrion.debug`) alongside the official release — no signature conflict, no need to uninstall either one to switch between them. Its Home Assistant/Harmony settings are configured independently the first time you install it (see Local configuration above), then kept per install from then on.
 
 ### Translations
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,10 +18,14 @@ android {
         minSdk = 26
         targetSdk = 34
         versionCode = 1
-        versionName = "1.0.1"
+        versionName = "1.0.2"
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix = ".debug"
+            versionNameSuffix = "-beta"
+        }
         release {
             isMinifyEnabled = false
         }

--- a/app/src/main/assets/docs/index.html
+++ b/app/src/main/assets/docs/index.html
@@ -12,12 +12,13 @@
 <div class="subtitle">Build your dashboard visually, no hand-written JSON required. Matches the exact schema the app reads.</div>
 <div id="deviceModeBanner" class="note" style="display:none"></div>
 
-<div class="beta-toggle-row" style="display:flex;align-items:center;gap:10px;margin-top:6px;">
+<div class="release-info-row" style="display:flex;align-items:center;gap:16px;margin-top:6px;flex-wrap:wrap;">
+  <span id="stableBadge"></span>
   <label class="beta-switch">
     <input type="checkbox" id="betaToggle" onchange="toggleBetaBadge()">
     <span class="beta-slider"></span>
   </label>
-  <span>Version bêta (dev)</span>
+  <span>Aussi la bêta (dev)</span>
   <span id="betaBadge" style="display:none"></span>
 </div>
 
@@ -401,6 +402,6 @@
 <script src="js/export.js"></script>
 <script src="js/preview.js"></script>
 <script src="js/device.js"></script>
-<script>initEditor();</script>
+<script>initEditor(); loadStableBadge();</script>
 </body>
 </html>

--- a/app/src/main/assets/docs/index.html
+++ b/app/src/main/assets/docs/index.html
@@ -12,6 +12,15 @@
 <div class="subtitle">Build your dashboard visually, no hand-written JSON required. Matches the exact schema the app reads.</div>
 <div id="deviceModeBanner" class="note" style="display:none"></div>
 
+<div class="beta-toggle-row" style="display:flex;align-items:center;gap:10px;margin-top:6px;">
+  <label class="beta-switch">
+    <input type="checkbox" id="betaToggle" onchange="toggleBetaBadge()">
+    <span class="beta-slider"></span>
+  </label>
+  <span>Version bêta (dev)</span>
+  <span id="betaBadge" style="display:none"></span>
+</div>
+
 <div class="layout">
   <!-- LEFT PANE -->
   <div class="editor-pane">

--- a/app/src/main/assets/docs/js/hotkeys.js
+++ b/app/src/main/assets/docs/js/hotkeys.js
@@ -1,24 +1,5 @@
 // ---- Hotkeys --------------------------------------------------------------
 
-async function toggleBetaBadge() {
-  const on = document.getElementById('betaToggle').checked;
-  const badge = document.getElementById('betaBadge');
-  if (!on) { badge.style.display = 'none'; return; }
-  badge.textContent = 'Chargement…';
-  badge.style.display = 'inline-block';
-  try {
-    const res = await fetch('https://api.github.com/repos/dckiller51/astrion-custom-dashboard/releases/tags/dev-latest');
-    if (!res.ok) throw new Error('HTTP ' + res.status);
-    const data = await res.json();
-    const asset = (data.assets || []).find(a => a.name.endsWith('.apk'));
-    badge.innerHTML = `🧪 ${data.name || data.tag_name}` +
-      (asset ? ` — <a href="${asset.browser_download_url}">télécharger l'APK</a>` : '');
-  } catch (e) {
-    badge.textContent = 'Bêta indisponible';
-    console.log('Beta release fetch failed', e);
-  }
-}
-
 function updateHotkeyActionInputs() {
   const action = document.getElementById('hkAction').value;
   const container = document.getElementById('dynamicHotkeyInputs');
@@ -263,4 +244,42 @@ function addHotkey() {
   target[hkType].push(hkObj);
 
   renderHotkeysList(); renderPreview(); updateJsonOutput();
+}
+
+// ---- Release badges (official + beta) --------------------------------------
+
+async function fetchReleaseBadge(url, icon) {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const data = await res.json();
+    const asset = (data.assets || []).find(a => a.name.endsWith('.apk'));
+    return `${icon} ${data.name || data.tag_name}` +
+      (asset ? ` — <a href="${asset.browser_download_url}">télécharger l'APK</a>` : '');
+  } catch (e) {
+    console.log('Release fetch failed', e);
+    return null;
+  }
+}
+
+async function loadStableBadge() {
+  const badge = document.getElementById('stableBadge');
+  if (!badge) return;
+  badge.textContent = 'Chargement…';
+  const html = await fetchReleaseBadge(
+    'https://api.github.com/repos/dckiller51/astrion-custom-dashboard/releases/latest', '✅'
+  );
+  badge.innerHTML = html || 'Version officielle indisponible';
+}
+
+async function toggleBetaBadge() {
+  const on = document.getElementById('betaToggle').checked;
+  const badge = document.getElementById('betaBadge');
+  if (!on) { badge.style.display = 'none'; return; }
+  badge.textContent = 'Chargement…';
+  badge.style.display = 'inline-block';
+  const html = await fetchReleaseBadge(
+    'https://api.github.com/repos/dckiller51/astrion-custom-dashboard/releases/tags/dev-latest', '🧪'
+  );
+  badge.innerHTML = html || 'Bêta indisponible';
 }

--- a/app/src/main/assets/docs/js/hotkeys.js
+++ b/app/src/main/assets/docs/js/hotkeys.js
@@ -1,5 +1,24 @@
 // ---- Hotkeys --------------------------------------------------------------
 
+async function toggleBetaBadge() {
+  const on = document.getElementById('betaToggle').checked;
+  const badge = document.getElementById('betaBadge');
+  if (!on) { badge.style.display = 'none'; return; }
+  badge.textContent = 'Chargement…';
+  badge.style.display = 'inline-block';
+  try {
+    const res = await fetch('https://api.github.com/repos/dckiller51/astrion-custom-dashboard/releases/tags/dev-latest');
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const data = await res.json();
+    const asset = (data.assets || []).find(a => a.name.endsWith('.apk'));
+    badge.innerHTML = `🧪 ${data.name || data.tag_name}` +
+      (asset ? ` — <a href="${asset.browser_download_url}">télécharger l'APK</a>` : '');
+  } catch (e) {
+    badge.textContent = 'Bêta indisponible';
+    console.log('Beta release fetch failed', e);
+  }
+}
+
 function updateHotkeyActionInputs() {
   const action = document.getElementById('hkAction').value;
   const container = document.getElementById('dynamicHotkeyInputs');

--- a/app/src/main/assets/docs/js/preview.js
+++ b/app/src/main/assets/docs/js/preview.js
@@ -368,11 +368,10 @@ function renderPreview() {
   if (hkInfo) {
     if (globalKeys + pageKeys > 0) {
       let hkHtml = `<div class="hotkeys-badge"><strong>⚡ Hotkeys active on this page:</strong><br>`;
-      const describe = (h) => h.page ? `→ page "${h.page}"` : h.service ? `→ ${h.service}` : h.harmonyCommand ? `→ Harmony ${h.harmonyCommand}` : h.harmonyActivity ? `→ Harmony activity ${h.harmonyActivity}` : '';
-      (dashboardData.hotkeys || []).forEach(h => hkHtml += `• [Global] <b>${h.key}</b> ${describe(h)}<br>`);
-      (dashboardData.longHotkeys || []).forEach(h => hkHtml += `• [Global, long] <b>${h.key}</b> ${describe(h)}<br>`);
-      (page.hotkeys || []).forEach(h => hkHtml += `• [Page] <b>${h.key}</b> ${describe(h)}<br>`);
-      (page.longHotkeys || []).forEach(h => hkHtml += `• [Page, long] <b>${h.key}</b> ${describe(h)}<br>`);
+      (dashboardData.hotkeys || []).forEach(h => hkHtml += `• [Global] <b>${h.key}</b> ${describeHotkey(h)}<br>`);
+      (dashboardData.longHotkeys || []).forEach(h => hkHtml += `• [Global, long] <b>${h.key}</b> ${describeHotkey(h)}<br>`);
+      (page.hotkeys || []).forEach(h => hkHtml += `• [Page] <b>${h.key}</b> ${describeHotkey(h)}<br>`);
+      (page.longHotkeys || []).forEach(h => hkHtml += `• [Page, long] <b>${h.key}</b> ${describeHotkey(h)}<br>`);
       hkHtml += `</div>`;
       hkInfo.innerHTML = hkHtml;
     } else {

--- a/app/src/main/assets/docs/styles.css
+++ b/app/src/main/assets/docs/styles.css
@@ -4,6 +4,12 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   .layout { display: flex; gap: 20px; align-items: flex-start; }
   .editor-pane, .preview-pane { flex: 1; background: #1e1e1e; border: 1px solid #333; border-radius: 12px; padding: 20px; min-width: 0; }
   .preview-pane { position: sticky; top: 20px; background: #181818; }
+  .beta-switch { position: relative; display: inline-block; width: 40px; height: 22px; }
+  .beta-switch input { opacity: 0; width: 0; height: 0; }
+  .beta-slider { position: absolute; inset: 0; background-color: #555; transition: .2s; border-radius: 22px; cursor: pointer; }
+  .beta-slider:before { position: absolute; content: ""; height: 16px; width: 16px; left: 3px; bottom: 3px; background-color: #fff; transition: .2s; border-radius: 50%; }
+  .beta-switch input:checked + .beta-slider { background-color: #00E5FF; }
+  .beta-switch input:checked + .beta-slider:before { transform: translateX(18px); }
   h2 { color: #00E5FF; font-size: 1.05rem; margin: 24px 0 10px; }
   h2:first-child { margin-top: 0; }
   label { font-size: 0.8rem; color: #aaa; display: block; margin: 8px 0 4px; }

--- a/app/src/main/java/com/custom/astrion/ui/SettingsMenu.kt
+++ b/app/src/main/java/com/custom/astrion/ui/SettingsMenu.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BrightnessMedium
 import androidx.compose.material.icons.filled.SettingsSuggest
+import androidx.compose.material.icons.filled.SystemUpdate
 import androidx.compose.material.icons.filled.Vibration
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.material3.Icon
@@ -27,11 +28,13 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -45,8 +48,12 @@ import androidx.compose.ui.unit.sp
 import com.custom.astrion.R
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.ha.ConnectionState
+import com.custom.astrion.update.UpdateChecker
 import java.net.Inet4Address
 import java.net.NetworkInterface
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * Settings panel in the style of HaRemote (their SettingActivity /
@@ -65,6 +72,19 @@ import java.net.NetworkInterface
 fun SettingsMenu(ctx: CardContext) {
     val context = LocalContext.current
     val activity = context as? Activity
+    val scope = rememberCoroutineScope()
+    var updateInfo by remember { mutableStateOf<UpdateChecker.UpdateInfo?>(null) }
+
+    // Checked once each time the Settings panel is opened — not on a
+    // background timer, to avoid polling GitHub while the app just sits on
+    // the dashboard. Always compares against the official /releases/latest,
+    // so this never fires for a newer beta build, only a newer official one.
+    LaunchedEffect(Unit) {
+        val result = withContext(Dispatchers.IO) { UpdateChecker.checkForUpdate() }
+        if (result is UpdateChecker.CheckResult.Available) {
+            updateInfo = result.info
+        }
+    }
 
     Column(
         modifier =
@@ -81,6 +101,19 @@ fun SettingsMenu(ctx: CardContext) {
             fontSize = 16.sp,
             fontWeight = FontWeight.SemiBold
         )
+
+        updateInfo?.let { info ->
+            SettingRow(icon = Icons.Filled.SystemUpdate, label = "Mise à jour disponible : v${info.version}") {
+                scope.launch(Dispatchers.IO) {
+                    val file = UpdateChecker.download(context, info.apkUrl)
+                    if (file != null) {
+                        withContext(Dispatchers.Main) {
+                            UpdateChecker.promptInstall(context, file)
+                        }
+                    }
+                }
+            }
+        }
 
         localIpAddress()?.let { ip ->
             Text(

--- a/app/src/main/java/com/custom/astrion/update/UpdateChecker.kt
+++ b/app/src/main/java/com/custom/astrion/update/UpdateChecker.kt
@@ -100,7 +100,10 @@ object UpdateChecker {
     /** Minimal x.y.z comparison against current BuildConfig.VERSION_NAME — good enough for plain semver-ish tags like "1.4.0". */
     private fun isNewer(remote: String): Boolean {
         val r = remote.split(".").mapNotNull { it.toIntOrNull() }
-        val l = BuildConfig.VERSION_NAME.split(".").mapNotNull { it.toIntOrNull() }
+        // substringBefore("-") strips any suffix (e.g. the debug build's
+        // "-beta" from versionNameSuffix) so the numeric comparison below
+        // isn't silently truncated — see CHANGELOG 1.0.3 for the bug this fixes.
+        val l = BuildConfig.VERSION_NAME.substringBefore("-").split(".").mapNotNull { it.toIntOrNull() }
         for (i in 0 until maxOf(r.size, l.size)) {
             val rv = r.getOrElse(i) { 0 }
             val lv = l.getOrElse(i) { 0 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,12 +12,13 @@
 <div class="subtitle">Build your dashboard visually, no hand-written JSON required. Matches the exact schema the app reads.</div>
 <div id="deviceModeBanner" class="note" style="display:none"></div>
 
-<div class="beta-toggle-row" style="display:flex;align-items:center;gap:10px;margin-top:6px;">
+<div class="release-info-row" style="display:flex;align-items:center;gap:16px;margin-top:6px;flex-wrap:wrap;">
+  <span id="stableBadge"></span>
   <label class="beta-switch">
     <input type="checkbox" id="betaToggle" onchange="toggleBetaBadge()">
     <span class="beta-slider"></span>
   </label>
-  <span>Version bêta (dev)</span>
+  <span>Aussi la bêta (dev)</span>
   <span id="betaBadge" style="display:none"></span>
 </div>
 
@@ -401,6 +402,6 @@
 <script src="js/export.js"></script>
 <script src="js/preview.js"></script>
 <script src="js/device.js"></script>
-<script>initEditor();</script>
+<script>initEditor(); loadStableBadge();</script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,15 @@
 <div class="subtitle">Build your dashboard visually, no hand-written JSON required. Matches the exact schema the app reads.</div>
 <div id="deviceModeBanner" class="note" style="display:none"></div>
 
+<div class="beta-toggle-row" style="display:flex;align-items:center;gap:10px;margin-top:6px;">
+  <label class="beta-switch">
+    <input type="checkbox" id="betaToggle" onchange="toggleBetaBadge()">
+    <span class="beta-slider"></span>
+  </label>
+  <span>Version bêta (dev)</span>
+  <span id="betaBadge" style="display:none"></span>
+</div>
+
 <div class="layout">
   <!-- LEFT PANE -->
   <div class="editor-pane">

--- a/docs/js/hotkeys.js
+++ b/docs/js/hotkeys.js
@@ -1,24 +1,5 @@
 // ---- Hotkeys --------------------------------------------------------------
 
-async function toggleBetaBadge() {
-  const on = document.getElementById('betaToggle').checked;
-  const badge = document.getElementById('betaBadge');
-  if (!on) { badge.style.display = 'none'; return; }
-  badge.textContent = 'Chargement…';
-  badge.style.display = 'inline-block';
-  try {
-    const res = await fetch('https://api.github.com/repos/dckiller51/astrion-custom-dashboard/releases/tags/dev-latest');
-    if (!res.ok) throw new Error('HTTP ' + res.status);
-    const data = await res.json();
-    const asset = (data.assets || []).find(a => a.name.endsWith('.apk'));
-    badge.innerHTML = `🧪 ${data.name || data.tag_name}` +
-      (asset ? ` — <a href="${asset.browser_download_url}">télécharger l'APK</a>` : '');
-  } catch (e) {
-    badge.textContent = 'Bêta indisponible';
-    console.log('Beta release fetch failed', e);
-  }
-}
-
 function updateHotkeyActionInputs() {
   const action = document.getElementById('hkAction').value;
   const container = document.getElementById('dynamicHotkeyInputs');
@@ -263,4 +244,42 @@ function addHotkey() {
   target[hkType].push(hkObj);
 
   renderHotkeysList(); renderPreview(); updateJsonOutput();
+}
+
+// ---- Release badges (official + beta) --------------------------------------
+
+async function fetchReleaseBadge(url, icon) {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const data = await res.json();
+    const asset = (data.assets || []).find(a => a.name.endsWith('.apk'));
+    return `${icon} ${data.name || data.tag_name}` +
+      (asset ? ` — <a href="${asset.browser_download_url}">télécharger l'APK</a>` : '');
+  } catch (e) {
+    console.log('Release fetch failed', e);
+    return null;
+  }
+}
+
+async function loadStableBadge() {
+  const badge = document.getElementById('stableBadge');
+  if (!badge) return;
+  badge.textContent = 'Chargement…';
+  const html = await fetchReleaseBadge(
+    'https://api.github.com/repos/dckiller51/astrion-custom-dashboard/releases/latest', '✅'
+  );
+  badge.innerHTML = html || 'Version officielle indisponible';
+}
+
+async function toggleBetaBadge() {
+  const on = document.getElementById('betaToggle').checked;
+  const badge = document.getElementById('betaBadge');
+  if (!on) { badge.style.display = 'none'; return; }
+  badge.textContent = 'Chargement…';
+  badge.style.display = 'inline-block';
+  const html = await fetchReleaseBadge(
+    'https://api.github.com/repos/dckiller51/astrion-custom-dashboard/releases/tags/dev-latest', '🧪'
+  );
+  badge.innerHTML = html || 'Bêta indisponible';
 }

--- a/docs/js/hotkeys.js
+++ b/docs/js/hotkeys.js
@@ -1,5 +1,24 @@
 // ---- Hotkeys --------------------------------------------------------------
 
+async function toggleBetaBadge() {
+  const on = document.getElementById('betaToggle').checked;
+  const badge = document.getElementById('betaBadge');
+  if (!on) { badge.style.display = 'none'; return; }
+  badge.textContent = 'Chargement…';
+  badge.style.display = 'inline-block';
+  try {
+    const res = await fetch('https://api.github.com/repos/dckiller51/astrion-custom-dashboard/releases/tags/dev-latest');
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const data = await res.json();
+    const asset = (data.assets || []).find(a => a.name.endsWith('.apk'));
+    badge.innerHTML = `🧪 ${data.name || data.tag_name}` +
+      (asset ? ` — <a href="${asset.browser_download_url}">télécharger l'APK</a>` : '');
+  } catch (e) {
+    badge.textContent = 'Bêta indisponible';
+    console.log('Beta release fetch failed', e);
+  }
+}
+
 function updateHotkeyActionInputs() {
   const action = document.getElementById('hkAction').value;
   const container = document.getElementById('dynamicHotkeyInputs');

--- a/docs/js/preview.js
+++ b/docs/js/preview.js
@@ -368,11 +368,10 @@ function renderPreview() {
   if (hkInfo) {
     if (globalKeys + pageKeys > 0) {
       let hkHtml = `<div class="hotkeys-badge"><strong>⚡ Hotkeys active on this page:</strong><br>`;
-      const describe = (h) => h.page ? `→ page "${h.page}"` : h.service ? `→ ${h.service}` : h.harmonyCommand ? `→ Harmony ${h.harmonyCommand}` : h.harmonyActivity ? `→ Harmony activity ${h.harmonyActivity}` : '';
-      (dashboardData.hotkeys || []).forEach(h => hkHtml += `• [Global] <b>${h.key}</b> ${describe(h)}<br>`);
-      (dashboardData.longHotkeys || []).forEach(h => hkHtml += `• [Global, long] <b>${h.key}</b> ${describe(h)}<br>`);
-      (page.hotkeys || []).forEach(h => hkHtml += `• [Page] <b>${h.key}</b> ${describe(h)}<br>`);
-      (page.longHotkeys || []).forEach(h => hkHtml += `• [Page, long] <b>${h.key}</b> ${describe(h)}<br>`);
+      (dashboardData.hotkeys || []).forEach(h => hkHtml += `• [Global] <b>${h.key}</b> ${describeHotkey(h)}<br>`);
+      (dashboardData.longHotkeys || []).forEach(h => hkHtml += `• [Global, long] <b>${h.key}</b> ${describeHotkey(h)}<br>`);
+      (page.hotkeys || []).forEach(h => hkHtml += `• [Page] <b>${h.key}</b> ${describeHotkey(h)}<br>`);
+      (page.longHotkeys || []).forEach(h => hkHtml += `• [Page, long] <b>${h.key}</b> ${describeHotkey(h)}<br>`);
       hkHtml += `</div>`;
       hkInfo.innerHTML = hkHtml;
     } else {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -4,6 +4,12 @@ body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-
   .layout { display: flex; gap: 20px; align-items: flex-start; }
   .editor-pane, .preview-pane { flex: 1; background: #1e1e1e; border: 1px solid #333; border-radius: 12px; padding: 20px; min-width: 0; }
   .preview-pane { position: sticky; top: 20px; background: #181818; }
+  .beta-switch { position: relative; display: inline-block; width: 40px; height: 22px; }
+  .beta-switch input { opacity: 0; width: 0; height: 0; }
+  .beta-slider { position: absolute; inset: 0; background-color: #555; transition: .2s; border-radius: 22px; cursor: pointer; }
+  .beta-slider:before { position: absolute; content: ""; height: 16px; width: 16px; left: 3px; bottom: 3px; background-color: #fff; transition: .2s; border-radius: 50%; }
+  .beta-switch input:checked + .beta-slider { background-color: #00E5FF; }
+  .beta-switch input:checked + .beta-slider:before { transform: translateX(18px); }
   h2 { color: #00E5FF; font-size: 1.05rem; margin: 24px 0 10px; }
   h2:first-child { margin-top: 0; }
   label { font-size: 0.8rem; color: #aaa; display: block; margin: 8px 0 4px; }


### PR DESCRIPTION
- push-beta.ps1: pushes dev and publishes/updates the current local debug build to a rolling GitHub pre-release (dev-latest) in one command, with a versionName/CHANGELOG consistency check.
- app/build.gradle.kts: debug build type gets applicationIdSuffix ".debug" and versionNameSuffix "-beta" so beta and official coexist without a signature conflict.
- docs/index.html, docs/js/hotkeys.js: release badges (official always visible, beta behind a toggle) fetched live from the GitHub API.
- docs/js/preview.js: "Hotkeys active on this page" badge now reuses hotkeys.js's describeHotkey() instead of a stale local copy that never covered openOverlay/openCurrentActivityRoom.
- app/.../update/UpdateChecker.kt: isNewer() strips the versionName suffix before comparing, fixing false "update available" positives on beta builds.
- app/.../ui/SettingsMenu.kt: checks for a newer official release each time Settings is opened, with a tappable row to download + install directly.