### PR TITLE
feat: one-click beta install from the builder (device mode)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,7 +18,7 @@ android {
         minSdk = 26
         targetSdk = 34
         versionCode = 1
-        versionName = "1.0.2"
+        versionName = "1.0.3"
     }
 
     buildTypes {

--- a/app/src/main/assets/docs/js/hotkeys.js
+++ b/app/src/main/assets/docs/js/hotkeys.js
@@ -281,5 +281,36 @@ async function toggleBetaBadge() {
   const html = await fetchReleaseBadge(
     'https://api.github.com/repos/dckiller51/astrion-custom-dashboard/releases/tags/dev-latest', '🧪'
   );
-  badge.innerHTML = html || 'Bêta indisponible';
+  if (!html) {
+    badge.innerHTML = 'Bêta indisponible';
+    return;
+  }
+  // In device mode (opened from the remote's own :8080), a real one-click
+  // install button posts to /install-beta-update — same-origin, so it runs
+  // server-side on the remote regardless of which browser/device clicked
+  // it, exactly like the existing official-update button. Outside device
+  // mode (e.g. GitHub Pages) there's no known device IP to target, so the
+  // plain download link from fetchReleaseBadge stays as the fallback.
+  if (typeof deviceModeAvailable !== 'undefined' && deviceModeAvailable) {
+    const label = html.replace(/ — <a[^>]*>.*?<\/a>/, '');
+    badge.innerHTML = `${label} — <button type="button" onclick="installBetaUpdate(this)" style="padding:4px 10px;font-size:0.8rem">Installer sur cet appareil</button>`;
+  } else {
+    badge.innerHTML = html;
+  }
+}
+
+async function installBetaUpdate(btn) {
+  const original = btn.textContent;
+  btn.textContent = 'Installation…';
+  btn.disabled = true;
+  try {
+    const res = await fetch('/install-beta-update', { method: 'POST' });
+    const text = await res.text();
+    if (!res.ok) throw new Error(text || ('HTTP ' + res.status));
+    showToast('Installation lancée sur la télécommande.');
+  } catch (e) {
+    showToast('Échec de l\'installation : ' + e.message, 'error');
+    btn.textContent = original;
+    btn.disabled = false;
+  }
 }

--- a/app/src/main/java/com/custom/astrion/update/UpdateChecker.kt
+++ b/app/src/main/java/com/custom/astrion/update/UpdateChecker.kt
@@ -27,6 +27,7 @@ object UpdateChecker {
     // "owner/repo" — the placeholder below will always report "no update".
     private const val REPO = "dckiller51/astrion-custom-dashboard"
     private const val API_URL = "https://api.github.com/repos/$REPO/releases/latest"
+    private const val BETA_API_URL = "https://api.github.com/repos/$REPO/releases/tags/dev-latest"
 
     data class UpdateInfo(val version: String, val notes: String, val apkUrl: String)
 
@@ -48,10 +49,45 @@ object UpdateChecker {
 
     /** Blocking network call — invoke off the main thread. */
     fun checkForUpdate(): CheckResult {
+        val release =
+            when (val fetch = fetchRelease(API_URL)) {
+                is FetchResult.Err -> return fetch.failed
+                is FetchResult.Ok -> fetch.release
+            }
+        val tag = release.tag.removePrefix("v")
+        if (!isNewer(tag)) return CheckResult.UpToDate
+        return releaseToResult(release, tag)
+    }
+
+    /**
+     * Same idea as [checkForUpdate], but against the rolling `dev-latest`
+     * pre-release instead of the official `/releases/latest` — always
+     * reports it as installable regardless of [isNewer], since a beta build
+     * has no meaningful "already up to date" comparison against a tag that
+     * gets overwritten on every push to dev.
+     */
+    fun checkBetaUpdate(): CheckResult {
+        val release =
+            when (val fetch = fetchRelease(BETA_API_URL)) {
+                is FetchResult.Err -> return fetch.failed
+                is FetchResult.Ok -> fetch.release
+            }
+        return releaseToResult(release, release.tag)
+    }
+
+    private data class RawRelease(val tag: String, val body: String, val apkUrl: String?)
+
+    private sealed class FetchResult {
+        data class Ok(val release: RawRelease) : FetchResult()
+
+        data class Err(val failed: CheckResult.Failed) : FetchResult()
+    }
+
+    private fun fetchRelease(url: String): FetchResult {
         val request =
             Request
                 .Builder()
-                .url(API_URL)
+                .url(url)
                 .header("Accept", "application/vnd.github+json")
                 .build()
 
@@ -59,29 +95,32 @@ object UpdateChecker {
             try {
                 http.newCall(request).execute()
             } catch (e: IOException) {
-                return CheckResult.Failed("Network error: ${e.message}")
+                return FetchResult.Err(CheckResult.Failed("Network error: ${e.message}"))
             }
 
         response.use { resp ->
             if (!resp.isSuccessful) {
-                return CheckResult.Failed(
-                    "GitHub API returned HTTP ${resp.code} for $REPO — check the REPO constant " +
-                        "in UpdateChecker.kt, and that the release isn't a draft or pre-release " +
-                        "(the /latest endpoint ignores both)."
+                return FetchResult.Err(
+                    CheckResult.Failed(
+                        "GitHub API returned HTTP ${resp.code} for $url — check the REPO constant " +
+                            "in UpdateChecker.kt, and that the release isn't a draft " +
+                            "(the /latest endpoint additionally ignores pre-releases)."
+                    )
                 )
             }
-            val bodyText = resp.body?.string() ?: return CheckResult.Failed("Empty response from GitHub")
+            val bodyText =
+                resp.body?.string()
+                    ?: return FetchResult.Err(CheckResult.Failed("Empty response from GitHub"))
 
             val root =
                 runCatching { Json.parseToJsonElement(bodyText).jsonObject }
-                    .getOrElse { return CheckResult.Failed("Could not parse GitHub response: ${it.message}") }
+                    .getOrElse {
+                        return FetchResult.Err(CheckResult.Failed("Could not parse GitHub response: ${it.message}"))
+                    }
 
             val tag =
-                root["tag_name"]?.jsonPrimitive?.content?.removePrefix("v")
-                    ?: return CheckResult.Failed("Latest release has no tag_name")
-
-            if (!isNewer(tag)) return CheckResult.UpToDate
-
+                root["tag_name"]?.jsonPrimitive?.content
+                    ?: return FetchResult.Err(CheckResult.Failed("Release has no tag_name"))
             val apkUrl =
                 root["assets"]
                     ?.jsonArray
@@ -90,11 +129,16 @@ object UpdateChecker {
                     ?.get("browser_download_url")
                     ?.jsonPrimitive
                     ?.content
-                    ?: return CheckResult.Failed("Release $tag has no .apk file attached as an asset")
-
-            val notes = root["body"]?.jsonPrimitive?.content.orEmpty()
-            return CheckResult.Available(UpdateInfo(version = tag, notes = notes, apkUrl = apkUrl))
+            val body = root["body"]?.jsonPrimitive?.content.orEmpty()
+            return FetchResult.Ok(RawRelease(tag = tag, body = body, apkUrl = apkUrl))
         }
+    }
+
+    private fun releaseToResult(release: RawRelease, displayVersion: String): CheckResult {
+        val apkUrl =
+            release.apkUrl
+                ?: return CheckResult.Failed("Release ${release.tag} has no .apk file attached as an asset")
+        return CheckResult.Available(UpdateInfo(version = displayVersion, notes = release.body, apkUrl = apkUrl))
     }
 
     /** Minimal x.y.z comparison against current BuildConfig.VERSION_NAME — good enough for plain semver-ish tags like "1.4.0". */

--- a/app/src/main/java/com/custom/astrion/web/ConfigServer.kt
+++ b/app/src/main/java/com/custom/astrion/web/ConfigServer.kt
@@ -74,6 +74,11 @@ import org.json.JSONObject
  *                        device (/builder/)
  *  GET  /check-update     check this project's GitHub Releases for a newer build
  *  POST /install-update   download the newer APK and open the system installer
+ *  POST /install-beta-update  same as /install-update but against the rolling
+ *                        dev-latest pre-release instead — always installs
+ *                        whatever the tag currently points to, no separate
+ *                        check step (used by the beta toggle in the builder,
+ *                        docs/js/hotkeys.js's installBetaUpdate())
  *  GET  /pages            list this device's dashboard pages (id + name), in
  *                        pager order — lets a remote controller (e.g. the
  *                        Home Assistant "astrion" integration) discover what
@@ -174,6 +179,7 @@ class ConfigServer(
             "/save-connection" -> if (method == Method.POST) handleSaveConnection(session) else methodNotAllowed()
             "/icons" -> if (method == Method.POST) handleIconUpload(session) else methodNotAllowed()
             "/install-update" -> if (method == Method.POST) handleInstallUpdate() else methodNotAllowed()
+            "/install-beta-update" -> if (method == Method.POST) handleInstallBetaUpdate() else methodNotAllowed()
             "/pages" -> if (method == Method.GET) servePages() else methodNotAllowed()
             "/current-page" -> if (method == Method.GET) serveCurrentPage() else methodNotAllowed()
             "/version" -> if (method == Method.GET) serveVersion() else methodNotAllowed()
@@ -1381,6 +1387,64 @@ class ConfigServer(
             redirectHome(context.getString(R.string.web_config_update_installing))
         } catch (e: Exception) {
             Log.e("ConfigServer", "install prompt failed", e)
+            newFixedLengthResponse(
+                Response.Status.INTERNAL_ERROR,
+                "text/plain",
+                "Could not open installer: ${e.message}"
+            )
+        }
+    }
+
+    /**
+     * Mirrors [handleInstallUpdate], but for the rolling `dev-latest`
+     * pre-release, and called via `fetch()` from docs/js/hotkeys.js's
+     * installBetaUpdate() rather than a `<form>` navigation — so this
+     * returns plain HTTP status + text instead of [redirectHome]'s
+     * meta-refresh HTML, which `fetch()` doesn't act on anyway and which
+     * always reports 200 OK even for a failure.
+     */
+    private fun handleInstallBetaUpdate(): Response {
+        val result = UpdateChecker.checkBetaUpdate()
+        val info =
+            (result as? UpdateChecker.CheckResult.Available)?.info
+                ?: return newFixedLengthResponse(
+                    Response.Status.INTERNAL_ERROR,
+                    "text/plain",
+                    when (result) {
+                        is UpdateChecker.CheckResult.Failed -> result.reason
+                        else -> "No beta build available"
+                    }
+                )
+
+        // Ask first instead of letting the installation intent fail: on Android 8+
+        // this permission is granted per-app in Settings, not at install time.
+        if (!context.packageManager.canRequestPackageInstalls()) {
+            val settingsIntent =
+                Intent(
+                    Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES,
+                    "package:${context.packageName}".toUri()
+                ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            runCatching { context.startActivity(settingsIntent) }
+            return newFixedLengthResponse(
+                Response.Status.FORBIDDEN,
+                "text/plain",
+                context.getString(R.string.web_config_update_needs_permission)
+            )
+        }
+
+        val file =
+            UpdateChecker.download(context, info.apkUrl)
+                ?: return newFixedLengthResponse(
+                    Response.Status.INTERNAL_ERROR,
+                    "text/plain",
+                    "Download failed"
+                )
+
+        return try {
+            UpdateChecker.promptInstall(context, file)
+            newFixedLengthResponse(Response.Status.OK, "text/plain", "Installing ${info.version}")
+        } catch (e: Exception) {
+            Log.e("ConfigServer", "beta install prompt failed", e)
             newFixedLengthResponse(
                 Response.Status.INTERNAL_ERROR,
                 "text/plain",

--- a/docs/js/hotkeys.js
+++ b/docs/js/hotkeys.js
@@ -281,5 +281,36 @@ async function toggleBetaBadge() {
   const html = await fetchReleaseBadge(
     'https://api.github.com/repos/dckiller51/astrion-custom-dashboard/releases/tags/dev-latest', '🧪'
   );
-  badge.innerHTML = html || 'Bêta indisponible';
+  if (!html) {
+    badge.innerHTML = 'Bêta indisponible';
+    return;
+  }
+  // In device mode (opened from the remote's own :8080), a real one-click
+  // install button posts to /install-beta-update — same-origin, so it runs
+  // server-side on the remote regardless of which browser/device clicked
+  // it, exactly like the existing official-update button. Outside device
+  // mode (e.g. GitHub Pages) there's no known device IP to target, so the
+  // plain download link from fetchReleaseBadge stays as the fallback.
+  if (typeof deviceModeAvailable !== 'undefined' && deviceModeAvailable) {
+    const label = html.replace(/ — <a[^>]*>.*?<\/a>/, '');
+    badge.innerHTML = `${label} — <button type="button" onclick="installBetaUpdate(this)" style="padding:4px 10px;font-size:0.8rem">Installer sur cet appareil</button>`;
+  } else {
+    badge.innerHTML = html;
+  }
+}
+
+async function installBetaUpdate(btn) {
+  const original = btn.textContent;
+  btn.textContent = 'Installation…';
+  btn.disabled = true;
+  try {
+    const res = await fetch('/install-beta-update', { method: 'POST' });
+    const text = await res.text();
+    if (!res.ok) throw new Error(text || ('HTTP ' + res.status));
+    showToast('Installation lancée sur la télécommande.');
+  } catch (e) {
+    showToast('Échec de l\'installation : ' + e.message, 'error');
+    btn.textContent = original;
+    btn.disabled = false;
+  }
 }


### PR DESCRIPTION
- UpdateChecker: extracted the release-fetch-and-parse logic shared by
  checkForUpdate() into fetchRelease()/FetchResult, and added
  checkBetaUpdate() against the rolling dev-latest pre-release —
  always reports it as installable (no isNewer() comparison, which
  has no meaningful "up to date" baseline against a tag that gets
  overwritten on every push to dev).
- ConfigServer: new POST /install-beta-update, mirroring
  handleInstallUpdate() but for the beta channel and returning plain
  HTTP status + text instead of redirectHome()'s meta-refresh HTML —
  this endpoint is called via fetch(), which doesn't act on a
  meta-refresh and would otherwise always see 200 OK even on failure.
- docs/js/hotkeys.js: in device mode, the beta badge now renders a
  real "Installer sur cet appareil" button posting to
  /install-beta-update (same-origin, so it runs server-side on the
  remote regardless of which browser/device clicked it — no need for
  the remote's own browser, same as the existing official-update
  button). Outside device mode (e.g. GitHub Pages, no known device IP)
  falls back to the plain download link