### PR TITLE
fix(cards): downsample oversized PNG icons on load

### DIFF
--- a/app/src/main/java/com/custom/astrion/cards/impl/ButtonGridCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/ButtonGridCard.kt
@@ -1,6 +1,5 @@
 package com.custom.astrion.cards.impl
 
-import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -18,7 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -29,8 +28,8 @@ import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.ServiceCall
 import com.custom.astrion.ui.ThemeColors
+import com.custom.astrion.ui.decodeIconSampled
 import com.custom.astrion.ui.tapClickable
-import java.io.File
 
 /**
  * Generic grid of action buttons, each firing a HA service call. Buttons can
@@ -91,14 +90,10 @@ class ButtonGridCard : CardRenderer {
     private fun GridButton(b: Map<String, Any?>, modifier: Modifier, theme: ThemeColors, onClick: () -> Unit) {
         val name = b["name"] as? String
         val iconPath = b["icon"] as? String
+        val targetPx = with(LocalDensity.current) { 32.dp.toPx() }.toInt()
         val bitmap =
-            remember(iconPath) {
-                iconPath?.let {
-                    runCatching {
-                        val f = File(it)
-                        if (f.exists()) BitmapFactory.decodeFile(f.absolutePath)?.asImageBitmap() else null
-                    }.getOrNull()
-                }
+            remember(iconPath, targetPx) {
+                iconPath?.let { decodeIconSampled(it, targetPx) }
             }
         val hasIcon = bitmap != null
 

--- a/app/src/main/java/com/custom/astrion/cards/impl/SceneGridCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/SceneGridCard.kt
@@ -1,6 +1,5 @@
 package com.custom.astrion.cards.impl
 
-import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
@@ -25,8 +24,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -36,8 +35,8 @@ import com.custom.astrion.cards.CardConfig
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.decodeIconSampled
 import com.custom.astrion.ui.tapClickable
-import java.io.File
 
 /**
  * Scene, activity, or navigation grid tile.
@@ -205,13 +204,16 @@ class SceneGridCard : CardRenderer {
     @Composable
     private fun SceneButton(state: SceneButtonState, layout: TileLayout, modifier: Modifier, onClick: () -> Unit) {
         val textColor = if (luminance(state.color) > 0.75f) Color(0xFF141414) else Color(0xFFF0F2F6)
-        val bitmap = remember(state.iconPath) {
-            state.iconPath?.let {
-                runCatching {
-                    val f = File(it)
-                    if (f.exists()) BitmapFactory.decodeFile(f.absolutePath)?.asImageBitmap() else null
-                }.getOrNull()
-            }
+        // iconFill tiles render the bitmap at the full tile height (ContentScale.
+        // FillHeight), otherwise it's a 28dp square — pick the larger of the two
+        // as the downsample target so the same bitmap stays sharp in either mode
+        // without decoding at the source's full (often 2000+px) resolution.
+        val targetPx =
+            with(LocalDensity.current) {
+                (if (layout.iconFill) layout.tileHeight else 28).dp.toPx()
+            }.toInt()
+        val bitmap = remember(state.iconPath, targetPx) {
+            state.iconPath?.let { decodeIconSampled(it, targetPx) }
         }
 
         if (state.hasIcon) {

--- a/app/src/main/java/com/custom/astrion/cards/impl/TitleCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/TitleCard.kt
@@ -1,6 +1,5 @@
 package com.custom.astrion.cards.impl
 
-import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -18,7 +17,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -28,8 +27,8 @@ import com.custom.astrion.cards.CardConfig
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.decodeIconSampled
 import com.custom.astrion.ui.tapClickable
-import java.io.File
 
 /**
  * Title card — a section header for grouping cards on a page, styled after
@@ -105,14 +104,10 @@ class TitleCard : CardRenderer {
             remember(config) {
                 config.string("color")?.let { parseHexColor(it) } ?: ctx.theme.primaryText
             }
+        val iconTargetPx = with(LocalDensity.current) { 22.dp.toPx() }.toInt()
         val iconBitmap =
-            remember(iconPath) {
-                iconPath?.let {
-                    runCatching {
-                        val f = File(it)
-                        if (f.exists()) BitmapFactory.decodeFile(f.absolutePath)?.asImageBitmap() else null
-                    }.getOrNull()
-                }
+            remember(iconPath, iconTargetPx) {
+                iconPath?.let { decodeIconSampled(it, iconTargetPx) }
             }
         // An icon or a divider forces the Bubble-Card-style left-aligned
         // "icon, label, line" row — see the class doc comment for why.

--- a/app/src/main/java/com/custom/astrion/ui/IconLoader.kt
+++ b/app/src/main/java/com/custom/astrion/ui/IconLoader.kt
@@ -1,0 +1,57 @@
+package com.custom.astrion.ui
+
+import android.graphics.BitmapFactory
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import java.io.File
+
+/**
+ * Decode a PNG icon from [path], downsampling oversized source images so a
+ * 2000+px-wide PNG displayed at ~28dp doesn't eat several MB of bitmap
+ * memory plus a matching GPU texture — the cause of the scrolling lag
+ * reported in upstream issue #36 on the HA100 hardware.
+ *
+ * Two-pass decode: first inspect the source dimensions with
+ * [BitmapFactory.Options.inJustDecodeBounds] (allocates nothing — only
+ * reads the header), compute an [BitmapFactory.Options.inSampleSize] that
+ * brings the longer edge down to around [targetPx], then decode for real.
+ * The result is an [ImageBitmap] close to the rendered size — at most ~2×
+ * the target on each axis, the floor `inSampleSize` (power-of-two-only)
+ * allows.
+ *
+ * Returns null on any I/O/decode failure or missing file, matching the
+ * prior `BitmapFactory.decodeFile()?.asImageBitmap()` convention so call
+ * sites keep their existing fallback (placeholder / blank spacer).
+ */
+fun decodeIconSampled(path: String, targetPx: Int): ImageBitmap? {
+    val f = File(path)
+    if (!f.exists()) return null
+    return runCatching {
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(f.absolutePath, bounds)
+        val sample = inSampleSizeFor(bounds.outWidth, bounds.outHeight, targetPx)
+        val opts = BitmapFactory.Options().apply { inSampleSize = sample }
+        BitmapFactory.decodeFile(f.absolutePath, opts)?.asImageBitmap()
+    }.getOrNull()
+}
+
+/**
+ * [BitmapFactory.Options.inSampleSize] for a decode whose longer edge
+ * should land at or above [targetPx]. `inSampleSize` is an int >= 1 that
+ * the decoder rounds down to the nearest power of two, so we step it up
+ * (halving the long edge each time) until the sampled long edge would be
+ * <= target — yielding at most ~2× target on each axis, the smallest
+ * sample that still satisfies the contract. Falls back to 1 (no sampling)
+ * when the source is already smaller than the target or its dimensions
+ * couldn't be read.
+ */
+private fun inSampleSizeFor(width: Int, height: Int, targetPx: Int): Int {
+    if (targetPx <= 0 || width <= 0 || height <= 0) return 1
+    var sample = 1
+    var longest = maxOf(width, height)
+    while (longest / 2 >= targetPx) {
+        longest /= 2
+        sample *= 2
+    }
+    return sample
+}


### PR DESCRIPTION
## Downsample oversized PNG icons on load (fixes #36)

### Problem
`BitmapFactory.decodeFile()` decoded PNG icons at full source resolution even though they are rendered at ~28dp. A 2170×550 source PNG consumed several MB of bitmap memory plus a matching GPU texture per icon — on the HA100 (1GB RAM, max GPU texture 4096×4096) this caused the severe scrolling lag reported in #36, and at larger source sizes icons stopped displaying entirely (bitmap exceeds the GPU max texture size and is silently dropped by `OpenGLRenderer`).

### Fix
Add `decodeIconSampled(path, targetPx)` in `ui/IconLoader.kt` — a two-pass decode:
1. Read dimensions with `inJustDecodeBounds = true` (no allocation, header only).
2. Compute `inSampleSize` so the longer edge lands at ~`targetPx` (at most ~2× target, the power-of-two floor `inSampleSize` allows).
3. Decode for real at the sampled size.

Each call site passes its actual rendered dp (converted to px via `LocalDensity`) as the target, so a 4340×1100 source displayed at 28dp decodes to a small bitmap instead of a multi-MB one.

### Files changed
- **`ui/IconLoader.kt`** (new) — the shared `decodeIconSampled` helper + `inSampleSizeFor` calculation.
- **`cards/impl/SceneGridCard.kt:208`** — target = `tile_height` dp in `icon_fill` mode, else 28 dp.
- **`cards/impl/ButtonGridCard.kt:94`** — target = 32 dp.
- **`cards/impl/TitleCard.kt:109`** — target = 22 dp.

### Left unchanged
- `cards/impl/PictureElementsCard.kt:88` — this is the full-size floorplan background image, not an icon; downsampling would degrade it. It is also already decoded off-thread via `produceState` + `Dispatchers.IO`.

### Verification
- `./gradlew ktlintFormat detekt` — clean.
- Built and installed `installDebug` on the HA100. Reproduced the original lag with 2170×550 icons, and the silent-drop with 4340×1100 icons (exceeds the 4096 max texture). After the fix, scrolling is smooth and icons render correctly at both source sizes.
- Tested on the "Dummy Scenes" page which has 10 `scene_grid` tiles using `icon-01.png` … `icon-10.png`.

### Notes
- Returns `null` on missing file or decode failure, matching the prior `BitmapFactory.decodeFile()?.asImageBitmap()` convention so call sites keep their existing fallback (blank spacer / placeholder).
- `remember` is keyed on `targetPx` in addition to `iconPath`, so a density/layout change re-decodes at the new target.
