### PR TITLE
perf(ui): reduce scroll lag and memory pressure on low-resource hardware

### DIFF
--- a/app/src/main/java/com/custom/astrion/cards/impl/CameraCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/CameraCard.kt
@@ -1,6 +1,5 @@
 package com.custom.astrion.cards.impl
 
-import android.graphics.BitmapFactory
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -33,10 +32,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -45,6 +45,7 @@ import androidx.compose.ui.window.Dialog
 import com.custom.astrion.cards.CardConfig
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
+import com.custom.astrion.ui.decodeByteArraySampled
 import com.custom.astrion.ui.icons.MdiIcons
 import java.io.BufferedInputStream
 import java.io.ByteArrayOutputStream
@@ -118,6 +119,13 @@ class CameraCard : CardRenderer {
         var live by remember(entityId, mode) { mutableStateOf(false) }
         var showMaximized by remember { mutableStateOf(false) }
 
+        // Target decode size: the card is fillMaxWidth, so the screen width
+        // in px is a close match. Downsample 720p/1080p MJPEG frames to this
+        // instead of decoding at full source resolution every frame.
+        val targetPx = with(LocalDensity.current) {
+            LocalConfiguration.current.screenWidthDp.dp.toPx()
+        }.toInt()
+
         LaunchedEffect(entityId, mode, ctx.screenOn) {
             if (entityId.isNullOrBlank()) {
                 error = true
@@ -185,7 +193,7 @@ class CameraCard : CardRenderer {
                         try {
                             resp.use { r ->
                                 if (!r.isSuccessful || r.body == null) return@runCatching false
-                                readMjpeg(r) { bmp ->
+                                readMjpeg(r, targetPx) { bmp ->
                                     frame = bmp
                                     error = false
                                     live = true
@@ -399,7 +407,7 @@ class CameraCard : CardRenderer {
      * Decoding happens on the IO dispatcher; only the tiny state write hops to
      * Main. Returns when the stream ends or the coroutine is cancelled.
      */
-    private suspend fun readMjpeg(resp: Response, onFrame: (ImageBitmap) -> Unit) {
+    private suspend fun readMjpeg(resp: Response, targetPx: Int, onFrame: (ImageBitmap) -> Unit) {
         withContext(Dispatchers.IO) {
             val input = BufferedInputStream(resp.body!!.byteStream(), 64 * 1024)
             val jpeg = ByteArrayOutputStream(96 * 1024)
@@ -419,13 +427,8 @@ class CameraCard : CardRenderer {
                             val bytes = jpeg.toByteArray()
                             jpeg.reset()
                             inFrame = false
-                            val bmp =
-                                try {
-                                    BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-                                } catch (e: Exception) {
-                                    null
-                                }
-                            if (bmp != null) withContext(Dispatchers.Main) { onFrame(bmp.asImageBitmap()) }
+                            val bmp = decodeByteArraySampled(bytes, targetPx)
+                            if (bmp != null) withContext(Dispatchers.Main) { onFrame(bmp) }
                         }
                     } else if (prev == 0xFF && b == 0xD8) {
                         inFrame = true

--- a/app/src/main/java/com/custom/astrion/cards/impl/PictureElementsCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/PictureElementsCard.kt
@@ -1,6 +1,5 @@
 package com.custom.astrion.cards.impl
 
-import android.graphics.BitmapFactory
 import android.os.Environment
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.RepeatMode
@@ -39,12 +38,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -54,8 +54,8 @@ import com.custom.astrion.cards.CardConfig
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
 import com.custom.astrion.ha.ServiceCall
+import com.custom.astrion.ui.decodeIconSampled
 import com.custom.astrion.ui.tapClickable
-import java.io.File
 import kotlin.math.PI
 import kotlin.math.cos
 import kotlin.math.sin
@@ -79,14 +79,17 @@ class PictureElementsCard : CardRenderer {
         val elements = (config.options["elements"] as? List<Map<String, Any?>>) ?: emptyList()
         var showVacuumDialog by remember { mutableStateOf(false) }
 
-        // Decode off-thread safely via produceState + Dispatchers.IO
-        val bitmap by produceState<ImageBitmap?>(initialValue = null, imagePath) {
+        // Decode off-thread, downsampled to the card's rendered width so a
+        // 2000+px floorplan PNG doesn't eat ~12MB of bitmap memory + a GPU
+        // texture that may exceed the HA100's 4096px max. The card is
+        // fillMaxWidth, so the screen width in px is a close target.
+        val targetPx = with(LocalDensity.current) {
+            LocalConfiguration.current.screenWidthDp.dp.toPx()
+        }.toInt()
+        val bitmap by produceState<ImageBitmap?>(initialValue = null, imagePath, targetPx) {
             value =
                 withContext(Dispatchers.IO) {
-                    runCatching {
-                        val f = File(imagePath)
-                        if (f.exists()) BitmapFactory.decodeFile(f.absolutePath)?.asImageBitmap() else null
-                    }.getOrNull()
+                    decodeIconSampled(imagePath, targetPx)
                 }
         }
 
@@ -229,12 +232,12 @@ class PictureElementsCard : CardRenderer {
                 .offset(x = x, y = y)
                 .tapClickable(onClick = onOpen)
         ) {
-            RoboVacIcon(vac = vac, docked = docked, moving = active)
+            RoboVacIcon(vac = vac, docked = docked, moving = active, screenOn = ctx.screenOn)
         }
     }
 
     @Composable
-    private fun RoboVacIcon(vac: Dp, docked: Boolean, moving: Boolean) {
+    private fun RoboVacIcon(vac: Dp, docked: Boolean, moving: Boolean, screenOn: Boolean) {
         val body = Color(0xFF3A4A52)
         val bump = Color(0xFF7B8C96)
 
@@ -253,7 +256,7 @@ class PictureElementsCard : CardRenderer {
             }
         } else {
             val angle =
-                if (moving) {
+                if (moving && screenOn) {
                     val t = rememberInfiniteTransition(label = "vacrock")
                     t
                         .animateFloat(
@@ -269,7 +272,7 @@ class PictureElementsCard : CardRenderer {
                 } else {
                     0f
                 }
-            VacBody(vac, body, bump, Modifier.rotate(angle))
+            VacBody(vac, body, bump, Modifier.graphicsLayer { rotationZ = angle })
         }
     }
 

--- a/app/src/main/java/com/custom/astrion/ui/Dashboard.kt
+++ b/app/src/main/java/com/custom/astrion/ui/Dashboard.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
@@ -677,16 +679,15 @@ private fun PageContent(page: PageConfig, ctx: CardContext) {
     val scrolling = page.cards.filter { it.options["pin"] != "bottom" }
 
     Column(modifier = Modifier.fillMaxSize()) {
-        Column(
+        LazyColumn(
             modifier =
             Modifier
                 .weight(1f)
                 .fillMaxWidth()
-                .verticalScroll(rememberScrollState())
                 .padding(horizontal = 10.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp)
         ) {
-            scrolling.forEach { RenderCard(it, ctx) }
+            items(scrolling, key = { it.hashCode() }) { RenderCard(it, ctx) }
         }
         if (pinned.isNotEmpty()) {
             Column(

--- a/app/src/main/java/com/custom/astrion/ui/IconLoader.kt
+++ b/app/src/main/java/com/custom/astrion/ui/IconLoader.kt
@@ -36,6 +36,23 @@ fun decodeIconSampled(path: String, targetPx: Int): ImageBitmap? {
 }
 
 /**
+ * Decode a JPEG byte array (e.g. an MJPEG frame) with the same two-pass
+ * downsample as [decodeIconSampled]. Camera streams are often 720p or
+ * 1080p but displayed at the card's rendered width (~480px on the HA100),
+ * so decoding every frame at full source resolution wastes CPU and
+ * creates large transient bitmaps that drive GC churn at 10-30 fps.
+ */
+fun decodeByteArraySampled(bytes: ByteArray, targetPx: Int): ImageBitmap? {
+    return runCatching {
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+        val sample = inSampleSizeFor(bounds.outWidth, bounds.outHeight, targetPx)
+        val opts = BitmapFactory.Options().apply { inSampleSize = sample }
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, opts)?.asImageBitmap()
+    }.getOrNull()
+}
+
+/**
  * [BitmapFactory.Options.inSampleSize] for a decode whose longer edge
  * should land at or above [targetPx]. `inSampleSize` is an int >= 1 that
  * the decoder rounds down to the nearest power of two, so we step it up


### PR DESCRIPTION
## UI performance optimizations for low-resource hardware

### Context
Following the icon downsample fix in #38, a broader audit found four more rendering performance issues affecting the HA100 (1GB RAM, MT6580 quad-A7, max GPU texture 4096×4096, Android 8.1). This PR addresses all four.

### Changes

**1. `Dashboard.kt` — LazyColumn instead of eager `Column.verticalScroll` (H1)**
`PageContent` composed every card on a page at once, including ones scrolled out of view. Off-screen cards stayed composed and kept doing background work — a `CameraCard` below the fold kept decoding MJPEG, a `PictureElementsCard` kept animating the vacuum, a `VacuumCard` kept re-fetching its map. Switched to `LazyColumn` so off-screen cards are disposed, which also disposes their `LaunchedEffect`s (camera streams stop, animations stop, fetches stop).

**2. `PictureElementsCard.kt` — Downsample floorplan PNG (H2)**
Same bug class as the icon issue in #38. The floorplan background was decoded at full source resolution via `BitmapFactory.decodeFile` even though it is displayed at the card rendered width (~480px on the HA100). A 2000×1500 floorplan consumed ~12MB of bitmap memory plus a matching GPU texture that can exceed the 4096px max and be silently dropped by `OpenGLRenderer`. Now decoded via `decodeIconSampled` targeted at the screen width in px. The existing `produceState` + `Dispatchers.IO` structure is preserved.

**3. `PictureElementsCard.kt` — Gate vacuum animation on `screenOn` (H3)**
The vacuum "rocking" `rememberInfiniteTransition` ran continuously while the vacuum state was `cleaning`/`returning`, ungated by `ctx.screenOn` — so it kept driving frames with the screen off overnight. Unlike `CameraCard` (which already checks `ctx.screenOn`), this animation had no such guard. Now gated on `ctx.screenOn`. Also switched from `Modifier.rotate(angle)` to `Modifier.graphicsLayer { rotationZ = angle }` (lambda form) so the animation read is deferred to the draw phase, skipping recomposition.

**4. `CameraCard.kt` — Sampled MJPEG decode (H4)**
Each JPEG frame in the MJPEG stream was decoded at full source resolution via `BitmapFactory.decodeByteArray`. Camera streams are typically 720p or 1080p but displayed at the card rendered width (~480px). Decoding 1080p JPEGs at 10-30fps is sustained heavy work for the MT6580 and produces large transient bitmaps (GC churn). Added `decodeByteArraySampled(bytes, targetPx)` to `IconLoader.kt` (same two-pass `inJustDecodeBounds` + `inSampleSize` approach as `decodeIconSampled`), targeted at the screen width in px. The `readMjpeg` function now takes a `targetPx` parameter.

### Files changed
- `ui/Dashboard.kt` — `LazyColumn` + `items` imports, `PageContent` body.
- `ui/IconLoader.kt` — new `decodeByteArraySampled` helper.
- `cards/impl/PictureElementsCard.kt` — sampled floorplan decode, `screenOn`-gated `graphicsLayer` rotation, import cleanup.
- `cards/impl/CameraCard.kt` — `targetPx` computation, `readMjpeg` signature, sampled frame decode, import cleanup.

### Verification
- `./gradlew ktlintFormat detekt` — clean.
- Built and installed `installDebug` on the HA100. App launches and renders correctly.
- Cherry-picks the icon downsample fix from #38 as a prerequisite (H2 and H4 build on `decodeIconSampled`).

### Notes
- The floorplan and camera target px use `LocalConfiguration.current.screenWidthDp` since both cards are `fillMaxWidth`. If a card is ever rendered at less than full width, the target will be slightly oversized — still a major improvement over full source resolution, and a safe upper bound.
- `LazyColumn` keys on `CardConfig.hashCode()` for stable item identity across recompositions.
