### PR TITLE
feat(i18n): localize remaining hardcoded UI strings

### DIFF
--- a/app/src/main/assets/docs/index.html
+++ b/app/src/main/assets/docs/index.html
@@ -18,7 +18,7 @@
     <input type="checkbox" id="betaToggle" onchange="toggleBetaBadge()">
     <span class="beta-slider"></span>
   </label>
-  <span>Aussi la bêta (dev)</span>
+  <span id="betaToggleLabel">Also the beta (dev)</span>
   <span id="betaBadge" style="display:none"></span>
 </div>
 
@@ -179,16 +179,16 @@
 
         <!-- ZONE 1: back / home / power -->
         <div class="remote-zone-container remote-zone-1">
-          <button class="hw-btn btn-retour btn-large30" title="Retour" data-hwkey="BACK">
+          <button class="hw-btn btn-retour btn-large30" title="Back" data-hwkey="BACK">
             <svg viewBox="0 0 24 24" class="icon-fill"><path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6 1.41-1.41z"/></svg>
           </button>
-          <button class="hw-btn btn-home recessed-pill" title="Accueil" data-hwkey="HOME">
+          <button class="hw-btn btn-home recessed-pill" title="Home" data-hwkey="HOME">
             <svg viewBox="0 0 24 24" class="icon-stroke">
               <path d="M2 11.5L12 3.5l10 8" />
               <path d="M5 13v8h14v-8" />
             </svg>
           </button>
-          <button class="hw-btn btn-power" title="Alimentation" data-hwkey="POWER">
+          <button class="hw-btn btn-power" title="Power" data-hwkey="POWER">
             <svg viewBox="0 0 24 24" class="icon-stroke" style="stroke-width: 1;">
               <line x1="12" y1="3" x2="12" y2="12" />
               <path d="M18.4 6.1a9 9 0 1 1-12.8 0" />
@@ -202,13 +202,13 @@
             <button class="hw-btn quad-btn top-left" title="Volume +" data-hwkey="VOLUME_UP">
               <svg viewBox="0 0 24 24" class="icon-fill"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
             </button>
-            <button class="hw-btn quad-btn top-right" title="Page precedente" data-hwkey="PAGE_UP">
+            <button class="hw-btn quad-btn top-right" title="Previous page" data-hwkey="PAGE_UP">
               <svg viewBox="0 0 24 24" class="icon-fill"><path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6 1.41 1.41z"/></svg>
             </button>
             <button class="hw-btn quad-btn bottom-left" title="Volume -" data-hwkey="VOLUME_DOWN">
               <svg viewBox="0 0 24 24" class="icon-fill"><path d="M19 13H5v-2h14v2z"/></svg>
             </button>
-            <button class="hw-btn quad-btn bottom-right" title="Page suivante" data-hwkey="PAGE_DOWN">
+            <button class="hw-btn quad-btn bottom-right" title="Next page" data-hwkey="PAGE_DOWN">
               <svg viewBox="0 0 24 24" class="icon-fill"><path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"/></svg>
             </button>
           </div>
@@ -223,7 +223,7 @@
 
         <!-- ZONE 3: media controls -->
         <div class="remote-zone-container remote-zone-3">
-          <button class="hw-btn" title="Muet" data-hwkey="MUTE">
+          <button class="hw-btn" title="Mute" data-hwkey="MUTE">
             <svg viewBox="0 0 24 24">
               <path d="M3 9h4l5-5v16l-5-5H3V9z" class="icon-stroke" /><path d="M16.59 12L14 9.41 15.41 8 18 10.59 20.59 8 22 9.41 19.41 12 22 14.59 20.59 16 18 13.41 15.41 16 14 14.59 16.59 12z" class="icon-fill" />
             </svg>
@@ -234,25 +234,25 @@
           <button class="hw-btn" title="Menu" data-hwkey="MAIN">
             <svg viewBox="0 0 24 24" class="icon-fill"><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
           </button>
-          <button class="hw-btn" title="Retour rapide" data-hwkey="REWIND">
+          <button class="hw-btn" title="Rewind" data-hwkey="REWIND">
             <svg viewBox="0 0 24 24" class="icon-stroke">
               <polygon points="11 18 3.5 12 11 6" />
               <polygon points="20.5 18 13 12 20.5 6" />
             </svg>
           </button>
-          <button class="hw-btn btn-play-pause" title="Lecture / Pause" data-hwkey="PLAY">
+          <button class="hw-btn btn-play-pause" title="Play / Pause" data-hwkey="PLAY">
             <svg viewBox="0 0 24 24">
               <polygon points="2 3 13 12 2 21" class="icon-stroke" />
               <rect x="16" y="4" width="2" height="16" rx="0.5" class="icon-fill" />
               <rect x="21" y="4" width="2" height="16" rx="0.5" class="icon-fill" />
             </svg>
           </button>
-          <button class="hw-btn" title="Arrêt" data-hwkey="STOP">
+          <button class="hw-btn" title="Stop" data-hwkey="STOP">
             <svg viewBox="0 0 24 24" class="icon-stroke">
               <rect x="6" y="6" width="12" height="12" rx="1" />
             </svg>
           </button>
-          <button class="hw-btn" title="Avance rapide" data-hwkey="FASTFORWARD">
+          <button class="hw-btn" title="Fast-forward" data-hwkey="FASTFORWARD">
             <svg viewBox="0 0 24 24" class="icon-stroke">
               <polygon points="13 18 20.5 12 13 6" />
               <polygon points="3.5 18 11 12 3.5 6" />
@@ -403,6 +403,6 @@
 <script src="js/export.js"></script>
 <script src="js/preview.js"></script>
 <script src="js/device.js"></script>
-<script>initEditor(); loadStableBadge();</script>
+<script>applyUiI18n(); initEditor(); loadStableBadge();</script>
 </body>
 </html>

--- a/app/src/main/assets/docs/js/hotkeys.js
+++ b/app/src/main/assets/docs/js/hotkeys.js
@@ -342,6 +342,58 @@ function addHotkey() {
 
 // ---- Release badges (official + beta) --------------------------------------
 
+const RELEASE_STRINGS = {
+  en: {
+    loading: 'Loading…',
+    stableUnavailable: 'Official release unavailable',
+    betaUnavailable: 'Beta unavailable',
+    downloadApk: 'download the APK',
+    installToDevice: 'Install on this device',
+    installing: 'Installing…',
+    installStarted: 'Install launched on the remote.',
+    installFailed: 'Install failed: ',
+    alsoBeta: 'Also the beta (dev)'
+  },
+  fr: {
+    loading: 'Chargement…',
+    stableUnavailable: 'Version officielle indisponible',
+    betaUnavailable: 'Bêta indisponible',
+    downloadApk: "télécharger l'APK",
+    installToDevice: 'Installer sur cet appareil',
+    installing: 'Installation…',
+    installStarted: 'Installation lancée sur la télécommande.',
+    installFailed: "Échec de l'installation : ",
+    alsoBeta: 'Aussi la bêta (dev)'
+  }
+};
+
+const HW_KEY_TITLES = {
+  en: {
+    BACK: 'Back', HOME: 'Home', POWER: 'Power', VOLUME_UP: 'Volume +',
+    PAGE_UP: 'Previous page', VOLUME_DOWN: 'Volume -', PAGE_DOWN: 'Next page',
+    MUTE: 'Mute', VOICE: 'Microphone', MAIN: 'Menu', REWIND: 'Rewind',
+    PLAY: 'Play / Pause', STOP: 'Stop', FASTFORWARD: 'Fast-forward'
+  },
+  fr: {
+    BACK: 'Retour', HOME: 'Accueil', POWER: 'Alimentation', VOLUME_UP: 'Volume +',
+    PAGE_UP: 'Page précédente', VOLUME_DOWN: 'Volume -', PAGE_DOWN: 'Page suivante',
+    MUTE: 'Muet', VOICE: 'Microphone', MAIN: 'Menu', REWIND: 'Retour rapide',
+    PLAY: 'Lecture / Pause', STOP: 'Arrêt', FASTFORWARD: 'Avance rapide'
+  }
+};
+
+const uiLang = ((navigator.language || 'en').split('-')[0]).startsWith('fr') ? 'fr' : 'en';
+const t = (key) => RELEASE_STRINGS[uiLang][key];
+
+function applyUiI18n() {
+  const betaLabel = document.getElementById('betaToggleLabel');
+  if (betaLabel) betaLabel.textContent = t('alsoBeta');
+  document.querySelectorAll('button[data-hwkey]').forEach(btn => {
+    const title = HW_KEY_TITLES[uiLang][btn.dataset.hwkey];
+    if (title) btn.title = title;
+  });
+}
+
 async function fetchReleaseBadge(url, icon) {
   try {
     const res = await fetch(url);
@@ -349,7 +401,7 @@ async function fetchReleaseBadge(url, icon) {
     const data = await res.json();
     const asset = (data.assets || []).find(a => a.name.endsWith('.apk'));
     return `${icon} ${data.name || data.tag_name}` +
-      (asset ? ` — <a href="${asset.browser_download_url}">télécharger l'APK</a>` : '');
+      (asset ? ` — <a href="${asset.browser_download_url}">${t('downloadApk')}</a>` : '');
   } catch (e) {
     console.log('Release fetch failed', e);
     return null;
@@ -359,24 +411,24 @@ async function fetchReleaseBadge(url, icon) {
 async function loadStableBadge() {
   const badge = document.getElementById('stableBadge');
   if (!badge) return;
-  badge.textContent = 'Chargement…';
+  badge.textContent = t('loading');
   const html = await fetchReleaseBadge(
     'https://api.github.com/repos/dckiller51/astrion-custom-dashboard/releases/latest', '✅'
   );
-  badge.innerHTML = html || 'Version officielle indisponible';
+  badge.innerHTML = html || t('stableUnavailable');
 }
 
 async function toggleBetaBadge() {
   const on = document.getElementById('betaToggle').checked;
   const badge = document.getElementById('betaBadge');
   if (!on) { badge.style.display = 'none'; return; }
-  badge.textContent = 'Chargement…';
+  badge.textContent = t('loading');
   badge.style.display = 'inline-block';
   const html = await fetchReleaseBadge(
     'https://api.github.com/repos/dckiller51/astrion-custom-dashboard/releases/tags/dev-latest', '🧪'
   );
   if (!html) {
-    badge.innerHTML = 'Bêta indisponible';
+    badge.innerHTML = t('betaUnavailable');
     return;
   }
   // In device mode (opened from the remote's own :8080), a real one-click
@@ -387,7 +439,7 @@ async function toggleBetaBadge() {
   // plain download link from fetchReleaseBadge stays as the fallback.
   if (typeof deviceModeAvailable !== 'undefined' && deviceModeAvailable) {
     const label = html.replace(/ — <a[^>]*>.*?<\/a>/, '');
-    badge.innerHTML = `${label} — <button type="button" onclick="installBetaUpdate(this)" style="padding:4px 10px;font-size:0.8rem">Installer sur cet appareil</button>`;
+    badge.innerHTML = `${label} — <button type="button" onclick="installBetaUpdate(this)" style="padding:4px 10px;font-size:0.8rem">${t('installToDevice')}</button>`;
   } else {
     badge.innerHTML = html;
   }
@@ -395,15 +447,15 @@ async function toggleBetaBadge() {
 
 async function installBetaUpdate(btn) {
   const original = btn.textContent;
-  btn.textContent = 'Installation…';
+  btn.textContent = t('installing');
   btn.disabled = true;
   try {
     const res = await fetch('/install-beta-update', { method: 'POST' });
     const text = await res.text();
     if (!res.ok) throw new Error(text || ('HTTP ' + res.status));
-    showToast('Installation lancée sur la télécommande.');
+    showToast(t('installStarted'));
   } catch (e) {
-    showToast('Échec de l\'installation : ' + e.message, 'error');
+    showToast(t('installFailed') + e.message, 'error');
     btn.textContent = original;
     btn.disabled = false;
   }

--- a/app/src/main/java/com/custom/astrion/cards/impl/MediaBrowser.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/MediaBrowser.kt
@@ -1,5 +1,6 @@
 package com.custom.astrion.cards.impl
 
+import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -33,11 +34,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import com.custom.astrion.R
 import com.custom.astrion.ha.HaClient
 import com.custom.astrion.ui.ThemeColors
 import com.custom.astrion.ui.tapClickable
@@ -56,28 +60,28 @@ private data class MediaItem(
 )
 
 private class BrowserUiState {
-    var title by mutableStateOf("Media")
+    var title by mutableStateOf<String?>(null)
     var items by mutableStateOf<List<MediaItem>?>(null)
     var error by mutableStateOf<String?>(null)
 }
 
-private suspend fun loadFolder(client: HaClient, entityId: String, cid: String?, ctype: String?, state: BrowserUiState) {
+private suspend fun loadFolder(context: Context, client: HaClient, entityId: String, cid: String?, ctype: String?, state: BrowserUiState) {
     state.items = null
     state.error = null
     try {
         val result = client.browseMedia(entityId, cid, ctype)
         if (result == null) {
-            state.error = "Couldn't load media (timeout)"
+            state.error = context.getString(R.string.media_load_timeout)
             state.items = emptyList()
         } else {
-            state.title = (result["title"] as? JsonPrimitive)?.content ?: "Media"
+            state.title = (result["title"] as? JsonPrimitive)?.content
             state.items = (result["children"] as? JsonArray)?.mapNotNull { parseItem(it as? JsonObject) } ?: emptyList()
         }
     } catch (ex: Exception) {
         // Some media_player integrations return an unexpected shape for a given
         // folder (e.g. a non-object "result") — surface it instead of letting
         // it crash the whole app.
-        state.error = ex.message ?: "Couldn't load media"
+        state.error = ex.message ?: context.getString(R.string.media_load_failed)
         state.items = emptyList()
     }
 }
@@ -94,9 +98,10 @@ fun MediaBrowser(entityId: String, client: HaClient, theme: ThemeColors = ThemeC
     val state = remember { BrowserUiState() }
 
     // Reload whenever the depth changes (push/pop).
+    val context = LocalContext.current
     androidx.compose.runtime.LaunchedEffect(stack.size) {
         val (cid, ctype) = stack.last()
-        loadFolder(client, entityId, cid, ctype, state)
+        loadFolder(context, client, entityId, cid, ctype, state)
     }
 
     Dialog(onDismissRequest = onClose) {
@@ -129,7 +134,7 @@ private fun MediaBrowserBody(
                 Spacer(Modifier.width(6.dp))
             }
             Text(
-                state.title,
+                state.title ?: stringResource(R.string.media_default_title),
                 color = theme.primaryText,
                 fontSize = 17.sp,
                 fontWeight = FontWeight.SemiBold,
@@ -154,7 +159,7 @@ private fun MediaBrowserBody(
                 }
             items.isEmpty() ->
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    Text("Nothing here", color = theme.mutedText, fontSize = 14.sp)
+                    Text(stringResource(R.string.media_nothing_here), color = theme.mutedText, fontSize = 14.sp)
                 }
             else ->
                 LazyColumn(verticalArrangement = Arrangement.spacedBy(2.dp)) {

--- a/app/src/main/java/com/custom/astrion/cards/impl/MediaPlayerDetailDialog.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/MediaPlayerDetailDialog.kt
@@ -36,12 +36,14 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import com.custom.astrion.R
 import com.custom.astrion.ha.EntityState
 import com.custom.astrion.ha.HaClient
 import com.custom.astrion.ha.ServiceCall
@@ -153,7 +155,12 @@ fun MediaPlayerDetailDialog(
                         tint = theme.primaryText,
                         modifier = Modifier.size(16.dp)
                     )
-                    Text("Browse", color = theme.primaryText, fontSize = 13.sp, modifier = Modifier.padding(start = 6.dp))
+                    Text(
+                        stringResource(R.string.media_browse),
+                        color = theme.primaryText,
+                        fontSize = 13.sp,
+                        modifier = Modifier.padding(start = 6.dp)
+                    )
                 }
             }
 
@@ -207,7 +214,7 @@ fun MediaPlayerDetailDialog(
                         .tapClickable { mp(if (on) "turn_off" else "turn_on") },
                     contentAlignment = Alignment.Center
                 ) {
-                    Icon(MdiIcons.Power, contentDescription = "Toggle", tint = Color.White)
+                    Icon(MdiIcons.Power, contentDescription = stringResource(R.string.media_power_toggle), tint = Color.White)
                 }
             }
         }

--- a/app/src/main/java/com/custom/astrion/cards/impl/PlexCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/PlexCard.kt
@@ -27,10 +27,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.custom.astrion.R
 import com.custom.astrion.cards.CardConfig
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
@@ -143,15 +146,16 @@ class PlexCard : CardRenderer {
 
     @Composable
     private fun rememberPlexState(cfg: PlexConfig): PlexUiState {
+        val context = LocalContext.current
         val state = remember { PlexUiState() }
         LaunchedEffect(cfg.host, cfg.token, cfg.showOnDeck, cfg.showMovies, cfg.showShows, cfg.itemsPerRow) {
             try {
                 state.machineId = PlexApi.fetchIdentity(cfg.host, cfg.token)
                 val out = loadRows(cfg.host, cfg.token, cfg.showOnDeck, cfg.showMovies, cfg.showShows, cfg.itemsPerRow)
                 state.rows = out
-                if (out.isEmpty()) state.error = "No items returned from Plex"
+                if (out.isEmpty()) state.error = context.getString(R.string.plex_error_no_items)
             } catch (ex: Exception) {
-                state.error = ex.message ?: "Plex error"
+                state.error = ex.message ?: context.getString(R.string.plex_error_generic)
                 state.rows = emptyList()
             }
         }
@@ -195,7 +199,7 @@ class PlexCard : CardRenderer {
         val key = item.sectionKey
         if (key != null) {
             state.librarySectionKey = key
-            state.librarySectionTitle = item.sectionTitle ?: "Library"
+            state.librarySectionTitle = item.sectionTitle
         } else {
             // No section info from the server for this item — fall back to just
             // opening the app rather than doing nothing.
@@ -225,7 +229,7 @@ class PlexCard : CardRenderer {
                 host = cfg.host,
                 token = cfg.token,
                 sectionKey = sectionKey,
-                sectionTitle = state.librarySectionTitle ?: "Library",
+                sectionTitle = state.librarySectionTitle ?: stringResource(R.string.plex_library),
                 theme = theme,
                 onSelectItem = { item ->
                     state.librarySectionKey = null
@@ -284,7 +288,12 @@ class PlexCard : CardRenderer {
             )
             when {
                 rows == null ->
-                    Text("Loading…", color = theme.mutedText, fontSize = 13.sp, modifier = Modifier.padding(horizontal = 14.dp))
+                    Text(
+                        stringResource(R.string.media_loading),
+                        color = theme.mutedText,
+                        fontSize = 13.sp,
+                        modifier = Modifier.padding(horizontal = 14.dp)
+                    )
                 error != null ->
                     Text(error, color = theme.danger, fontSize = 13.sp, modifier = Modifier.padding(horizontal = 14.dp))
                 else ->

--- a/app/src/main/java/com/custom/astrion/cards/impl/PlexDetailDialog.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/PlexDetailDialog.kt
@@ -32,11 +32,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import com.custom.astrion.R
 import com.custom.astrion.ui.ThemeColors
 import com.custom.astrion.ui.icons.MdiIcons
 import com.custom.astrion.ui.tapClickable
@@ -75,7 +77,7 @@ internal fun PlexDetailDialog(
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             if (detail == null) {
-                Text("Loading…", color = theme.mutedText, fontSize = 13.sp)
+                Text(stringResource(R.string.media_loading), color = theme.mutedText, fontSize = 13.sp)
             } else {
                 DetailArt(host, token, detail, theme)
                 DetailHeader(detail, theme)
@@ -154,7 +156,7 @@ private fun EpisodeRow(
     onSelectEpisode: (PlexApi.PlexEpisodeSummary) -> Unit
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Text("This season", color = theme.mutedText, fontSize = 13.sp)
+        Text(stringResource(R.string.plex_this_season), color = theme.mutedText, fontSize = 13.sp)
         LazyRow(horizontalArrangement = Arrangement.spacedBy(10.dp), contentPadding = PaddingValues(vertical = 2.dp)) {
             items(episodes) { ep ->
                 EpisodeTile(host, token, ep, selected = ep.key == selectedKey, theme = theme) { onSelectEpisode(ep) }
@@ -188,7 +190,7 @@ private fun EpisodeTile(
             Box(mod)
         }
         Text(
-            "E${ep.index ?: "?"} · ${ep.title}",
+            stringResource(R.string.plex_episode, ep.index?.toString() ?: "?", ep.title),
             color = if (selected) theme.accent else theme.primaryText,
             fontSize = 10.sp,
             maxLines = 2,
@@ -211,6 +213,12 @@ private fun PlayButton(theme: ThemeColors, onClick: () -> Unit) {
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(MdiIcons.Play, contentDescription = null, tint = Color.White, modifier = Modifier.height(20.dp))
-        Text("Play", color = Color.White, fontSize = 15.sp, fontWeight = FontWeight.SemiBold, modifier = Modifier.padding(start = 6.dp))
+        Text(
+            stringResource(R.string.plex_play),
+            color = Color.White,
+            fontSize = 15.sp,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(start = 6.dp)
+        )
     }
 }

--- a/app/src/main/java/com/custom/astrion/cards/impl/PlexLibraryDialog.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/PlexLibraryDialog.kt
@@ -30,11 +30,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import com.custom.astrion.R
 import com.custom.astrion.ui.ThemeColors
 import com.custom.astrion.ui.tapClickable
 import kotlinx.coroutines.flow.collect
@@ -102,7 +104,13 @@ internal fun PlexLibraryDialog(
         ) {
             LibraryHeader(sectionTitle, totalSize, theme)
             if (items.isEmpty()) {
-                Text(if (loading) "Loading…" else "No items", color = theme.mutedText, fontSize = 13.sp)
+                val emptyLabel =
+                    if (loading) {
+                        stringResource(R.string.media_loading)
+                    } else {
+                        stringResource(R.string.media_no_items)
+                    }
+                Text(emptyLabel, color = theme.mutedText, fontSize = 13.sp)
             } else {
                 LazyVerticalGrid(
                     columns = GridCells.Fixed(3),
@@ -115,7 +123,7 @@ internal fun PlexLibraryDialog(
                         LibraryTile(host, token, item, theme) { onSelectItem(item) }
                     }
                 }
-                if (loading) Text("Loading more…", color = theme.mutedText, fontSize = 12.sp)
+                if (loading) Text(stringResource(R.string.media_loading_more), color = theme.mutedText, fontSize = 12.sp)
             }
         }
     }

--- a/app/src/main/java/com/custom/astrion/cards/impl/SelectCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/SelectCard.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -36,6 +37,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.toColorInt
+import com.custom.astrion.R
 import com.custom.astrion.cards.CardConfig
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
@@ -90,7 +92,12 @@ class SelectCard : CardRenderer {
         // shape to account for: state is always one of `options`, or
         // "unavailable"/"unknown" if the entity itself is down.
         val current = e?.state
-        val stateLabel = current ?: if (options.isEmpty()) "No options" else "Select…"
+        val stateLabel =
+            current ?: if (options.isEmpty()) {
+                stringResource(R.string.select_no_options)
+            } else {
+                stringResource(R.string.select_choose)
+            }
 
         val iconColor = config.string("icon_color")?.let(::parseHexColor)
 

--- a/app/src/main/java/com/custom/astrion/cards/impl/SourceSelectCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/SourceSelectCard.kt
@@ -22,9 +22,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.custom.astrion.R
 import com.custom.astrion.cards.CardConfig
 import com.custom.astrion.cards.CardContext
 import com.custom.astrion.cards.CardRenderer
@@ -72,7 +74,11 @@ class SourceSelectCard : CardRenderer {
                 Column(Modifier.weight(1f)) {
                     Text(name, color = ctx.theme.mutedText, fontSize = 11.sp)
                     Text(
-                        current ?: if (sources.isEmpty()) "No sources (device off?)" else "Select source…",
+                        current ?: if (sources.isEmpty()) {
+                            stringResource(R.string.source_no_sources)
+                        } else {
+                            stringResource(R.string.source_choose)
+                        },
                         color = ctx.theme.primaryText,
                         fontSize = 15.sp,
                         maxLines = 1,

--- a/app/src/main/java/com/custom/astrion/cards/impl/VacuumCard.kt
+++ b/app/src/main/java/com/custom/astrion/cards/impl/VacuumCard.kt
@@ -128,7 +128,7 @@ fun VacuumPanelContent(options: Map<String, Any?>, ctx: CardContext) {
     val entityId = options["entity_id"] as? String ?: return
     val e = ctx.entities[entityId]
     val state = e?.state ?: "unknown"
-    val name = options["name"] as? String ?: e?.friendlyName ?: "Vacuum"
+    val name = options["name"] as? String ?: e?.friendlyName ?: stringResource(R.string.vacuum_default_name)
     val fanSpeed = e?.attrString("fan_speed")
     val fanList = e?.attrStringList("fan_speed_list") ?: emptyList()
     val mapEntity = options["map_image"] as? String
@@ -209,7 +209,7 @@ fun VacuumPanelContent(options: Map<String, Any?>, ctx: CardContext) {
         ) {
             Image(
                 bitmap = bmp,
-                contentDescription = "Vacuum map",
+                contentDescription = stringResource(R.string.vacuum_map_label),
                 modifier = Modifier.fillMaxSize().graphicsLayer(scaleX = 1.9f, scaleY = 1.9f),
                 contentScale = ContentScale.Fit
             )

--- a/app/src/main/java/com/custom/astrion/ui/Dashboard.kt
+++ b/app/src/main/java/com/custom/astrion/ui/Dashboard.kt
@@ -874,10 +874,10 @@ private fun ConnectionBanner(connection: ConnectionState) {
         when (connection) {
             ConnectionState.CONNECTING,
             ConnectionState.AUTHENTICATING
-            -> "Connecting…" to LocalTheme.current.accentSecondary
-            ConnectionState.AUTH_FAILED -> "Auth failed — check token" to LocalTheme.current.danger
-            ConnectionState.ERROR -> "Connection error — retrying" to LocalTheme.current.danger
-            else -> "Disconnected" to LocalTheme.current.controlBackground
+            -> stringResource(R.string.connection_connecting) to LocalTheme.current.accentSecondary
+            ConnectionState.AUTH_FAILED -> stringResource(R.string.connection_auth_failed) to LocalTheme.current.danger
+            ConnectionState.ERROR -> stringResource(R.string.connection_error_retrying) to LocalTheme.current.danger
+            else -> stringResource(R.string.disconnected) to LocalTheme.current.controlBackground
         }
     Box(
         modifier =
@@ -913,6 +913,6 @@ private fun UnknownCard(type: String) {
             .background(LocalTheme.current.cardSurface)
             .padding(14.dp)
     ) {
-        Text(text = "Unknown card type: \"$type\"", color = LocalTheme.current.danger, fontSize = 13.sp)
+        Text(text = stringResource(R.string.unknown_card_type, type), color = LocalTheme.current.danger, fontSize = 13.sp)
     }
 }

--- a/app/src/main/java/com/custom/astrion/ui/SettingsMenu.kt
+++ b/app/src/main/java/com/custom/astrion/ui/SettingsMenu.kt
@@ -1,6 +1,7 @@
 package com.custom.astrion.ui
 
 import android.app.Activity
+import android.content.Context
 import android.content.Intent
 import android.provider.Settings
 import android.util.Log
@@ -53,6 +54,7 @@ import com.custom.astrion.ha.ConnectionState
 import com.custom.astrion.update.UpdateChecker
 import java.net.Inet4Address
 import java.net.NetworkInterface
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -122,27 +124,16 @@ fun SettingsMenu(ctx: CardContext) {
         )
 
         updateInfo?.let { info ->
-            val label =
-                if (updateIsBeta) {
-                    "Bêta disponible : ${info.version}"
-                } else {
-                    "Mise à jour disponible : v${info.version}"
-                }
-            SettingRow(icon = Icons.Filled.SystemUpdate, label = label) {
-                scope.launch(Dispatchers.IO) {
-                    val file = UpdateChecker.download(context, info.apkUrl)
-                    if (file != null) {
-                        withContext(Dispatchers.Main) {
-                            UpdateChecker.promptInstall(context, file)
-                        }
-                    }
-                }
-            }
+            UpdateRow(context, scope, info, updateIsBeta)
         }
 
         localIpAddress()?.let { ip ->
             Text(
-                if (ctx.configServerEnabled) "Local config: http://$ip:8080" else stringResource(R.string.config_server_off_hint),
+                if (ctx.configServerEnabled) {
+                    stringResource(R.string.settings_local_config, "http://$ip:8080")
+                } else {
+                    stringResource(R.string.config_server_off_hint)
+                },
                 color = if (ctx.configServerEnabled) LocalTheme.current.accent else LocalTheme.current.mutedText,
                 fontSize = 12.sp
             )
@@ -171,6 +162,26 @@ fun SettingsMenu(ctx: CardContext) {
 }
 
 @Composable
+private fun UpdateRow(context: Context, scope: CoroutineScope, info: UpdateChecker.UpdateInfo, isBeta: Boolean) {
+    val label =
+        if (isBeta) {
+            stringResource(R.string.settings_beta_update_available, info.version)
+        } else {
+            stringResource(R.string.settings_update_available, info.version)
+        }
+    SettingRow(icon = Icons.Filled.SystemUpdate, label = label) {
+        scope.launch(Dispatchers.IO) {
+            val file = UpdateChecker.download(context, info.apkUrl)
+            if (file != null) {
+                withContext(Dispatchers.Main) {
+                    UpdateChecker.promptInstall(context, file)
+                }
+            }
+        }
+    }
+}
+
+@Composable
 private fun ConnectionStatusSection(ctx: CardContext) {
     val haConnection by ctx.client.connection.collectAsState()
     val haConnected = haConnection == ConnectionState.CONNECTED
@@ -183,7 +194,7 @@ private fun ConnectionStatusSection(ctx: CardContext) {
             if (haConnected) {
                 stringResource(R.string.connected)
             } else {
-                haConnection.name.lowercase().replaceFirstChar { it.uppercase() }
+                stringResource(haStatusString(haConnection))
             }
         )
         ConnectionStatusRow(
@@ -192,6 +203,13 @@ private fun ConnectionStatusSection(ctx: CardContext) {
             detail = stringResource(if (ctx.harmonyConnected) R.string.connected else R.string.disconnected)
         )
     }
+}
+
+private fun haStatusString(state: ConnectionState): Int = when (state) {
+    ConnectionState.CONNECTING, ConnectionState.AUTHENTICATING -> R.string.connection_connecting
+    ConnectionState.AUTH_FAILED -> R.string.connection_auth_failed
+    ConnectionState.ERROR -> R.string.connection_error_retrying
+    else -> R.string.disconnected
 }
 
 @Composable

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -21,6 +21,9 @@
     <string name="tap_feedback_hint">Léger clic sonore quand vous tapotez une scène, un bouton ou un point — identique aux menus Android de l\'appareil.</string>
     <string name="brightness">Luminosité</string>
     <string name="allow_brightness_write">Autoriser la modification (appuyer)</string>
+    <string name="settings_update_available">Mise à jour disponible : v%1$s</string>
+    <string name="settings_beta_update_available">Bêta disponible : %1$s</string>
+    <string name="settings_local_config">Configuration locale : %1$s</string>
 
     <!-- Web Config: Header & General -->
     <string name="web_config_title">Astrion Custom — Configuration locale</string>
@@ -89,6 +92,37 @@
     <string name="web_config_update_needs_permission">Autorisez « Installer des applications inconnues » pour cette app sur l\'écran qui vient de s\'ouvrir, puis appuyez de nouveau sur Télécharger &amp; installer.</string>
     <string name="web_config_update_failed">Échec de la vérification : %1$s</string>
 
+    <!-- Connection status -->
+    <string name="connection_connecting">Connexion…</string>
+    <string name="connection_auth_failed">Échec de l\'authentification — vérifiez le jeton</string>
+    <string name="connection_error_retrying">Erreur de connexion — nouvelle tentative</string>
+
+    <!-- Unknown card -->
+    <string name="unknown_card_type">Type de carte inconnu : "%1$s"</string>
+
+    <!-- Media (player, Plex, browser) -->
+    <string name="media_loading">Chargement…</string>
+    <string name="media_loading_more">Chargement de la suite…</string>
+    <string name="media_no_items">Aucun élément</string>
+    <string name="media_nothing_here">Rien ici</string>
+    <string name="media_default_title">Médias</string>
+    <string name="media_load_timeout">Impossible de charger les médias (délai dépassé)</string>
+    <string name="media_load_failed">Impossible de charger les médias</string>
+    <string name="media_browse">Parcourir</string>
+    <string name="media_power_toggle">Basculer</string>
+    <string name="plex_error_no_items">Plex n\'a renvoyé aucun élément</string>
+    <string name="plex_error_generic">Erreur Plex</string>
+    <string name="plex_library">Bibliothèque</string>
+    <string name="plex_this_season">Cette saison</string>
+    <string name="plex_play">Lire</string>
+    <string name="plex_episode">Ép. %1$s · %2$s</string>
+
+    <!-- Select cards -->
+    <string name="select_no_options">Aucune option</string>
+    <string name="select_choose">Sélectionner…</string>
+    <string name="source_no_sources">Aucune source (appareil éteint ?)</string>
+    <string name="source_choose">Sélectionner une source…</string>
+
     <!-- ClimateCard -->
     <string name="climate_current_temp">Actuellement %1$s°</string>
     <string name="climate_hvac_caption">Mode</string>
@@ -103,6 +137,8 @@
 
     <!-- VacuumCard -->
     <string name="vacuum_fan_speed_caption">Mode de nettoyage</string>
+    <string name="vacuum_default_name">Aspirateur robot</string>
+    <string name="vacuum_map_label">Carte de l\'aspirateur robot</string>
 
     <!-- CoverCard -->
     <string name="cover_open">Ouvert</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,9 @@
     <string name="tap_feedback_hint">Short tick sound when you tap a scene, button, or dot — matches the device\'s own Android menus.</string>
     <string name="brightness">Brightness</string>
     <string name="allow_brightness_write">Allow brightness control (tap)</string>
+    <string name="settings_update_available">Update available: v%1$s</string>
+    <string name="settings_beta_update_available">Beta available: %1$s</string>
+    <string name="settings_local_config">Local config: %1$s</string>
 
     <!-- Web Config: Header & General -->
     <string name="web_config_title">Astrion Custom — Local configuration</string>
@@ -89,6 +92,37 @@
     <string name="web_config_update_needs_permission">Allow "Install unknown apps" for this app on the screen that just opened, then tap Download &amp; install again.</string>
     <string name="web_config_update_failed">Update check failed: %1$s</string>
 
+    <!-- Connection status -->
+    <string name="connection_connecting">Connecting…</string>
+    <string name="connection_auth_failed">Auth failed — check token</string>
+    <string name="connection_error_retrying">Connection error — retrying</string>
+
+    <!-- Unknown card -->
+    <string name="unknown_card_type">Unknown card type: "%1$s"</string>
+
+    <!-- Media (player, Plex, browser) -->
+    <string name="media_loading">Loading…</string>
+    <string name="media_loading_more">Loading more…</string>
+    <string name="media_no_items">No items</string>
+    <string name="media_nothing_here">Nothing here</string>
+    <string name="media_default_title">Media</string>
+    <string name="media_load_timeout">Couldn\'t load media (timeout)</string>
+    <string name="media_load_failed">Couldn\'t load media</string>
+    <string name="media_browse">Browse</string>
+    <string name="media_power_toggle">Toggle</string>
+    <string name="plex_error_no_items">No items returned from Plex</string>
+    <string name="plex_error_generic">Plex error</string>
+    <string name="plex_library">Library</string>
+    <string name="plex_this_season">This season</string>
+    <string name="plex_play">Play</string>
+    <string name="plex_episode">E%1$s · %2$s</string>
+
+    <!-- Select cards -->
+    <string name="select_no_options">No options</string>
+    <string name="select_choose">Select…</string>
+    <string name="source_no_sources">No sources (device off?)</string>
+    <string name="source_choose">Select source…</string>
+
     <!-- ClimateCard -->
     <string name="climate_current_temp">Now %1$s°</string>
     <string name="climate_hvac_caption">Mode</string>
@@ -103,6 +137,8 @@
 
     <!-- VacuumCard -->
     <string name="vacuum_fan_speed_caption">Cleaning mode</string>
+    <string name="vacuum_default_name">Vacuum</string>
+    <string name="vacuum_map_label">Vacuum map</string>
 
     <!-- CoverCard -->
     <string name="cover_open">Open</string>

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,7 +18,7 @@
     <input type="checkbox" id="betaToggle" onchange="toggleBetaBadge()">
     <span class="beta-slider"></span>
   </label>
-  <span>Aussi la bêta (dev)</span>
+  <span id="betaToggleLabel">Also the beta (dev)</span>
   <span id="betaBadge" style="display:none"></span>
 </div>
 
@@ -179,16 +179,16 @@
 
         <!-- ZONE 1: back / home / power -->
         <div class="remote-zone-container remote-zone-1">
-          <button class="hw-btn btn-retour btn-large30" title="Retour" data-hwkey="BACK">
+          <button class="hw-btn btn-retour btn-large30" title="Back" data-hwkey="BACK">
             <svg viewBox="0 0 24 24" class="icon-fill"><path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6 1.41-1.41z"/></svg>
           </button>
-          <button class="hw-btn btn-home recessed-pill" title="Accueil" data-hwkey="HOME">
+          <button class="hw-btn btn-home recessed-pill" title="Home" data-hwkey="HOME">
             <svg viewBox="0 0 24 24" class="icon-stroke">
               <path d="M2 11.5L12 3.5l10 8" />
               <path d="M5 13v8h14v-8" />
             </svg>
           </button>
-          <button class="hw-btn btn-power" title="Alimentation" data-hwkey="POWER">
+          <button class="hw-btn btn-power" title="Power" data-hwkey="POWER">
             <svg viewBox="0 0 24 24" class="icon-stroke" style="stroke-width: 1;">
               <line x1="12" y1="3" x2="12" y2="12" />
               <path d="M18.4 6.1a9 9 0 1 1-12.8 0" />
@@ -202,13 +202,13 @@
             <button class="hw-btn quad-btn top-left" title="Volume +" data-hwkey="VOLUME_UP">
               <svg viewBox="0 0 24 24" class="icon-fill"><path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/></svg>
             </button>
-            <button class="hw-btn quad-btn top-right" title="Page precedente" data-hwkey="PAGE_UP">
+            <button class="hw-btn quad-btn top-right" title="Previous page" data-hwkey="PAGE_UP">
               <svg viewBox="0 0 24 24" class="icon-fill"><path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6 1.41 1.41z"/></svg>
             </button>
             <button class="hw-btn quad-btn bottom-left" title="Volume -" data-hwkey="VOLUME_DOWN">
               <svg viewBox="0 0 24 24" class="icon-fill"><path d="M19 13H5v-2h14v2z"/></svg>
             </button>
-            <button class="hw-btn quad-btn bottom-right" title="Page suivante" data-hwkey="PAGE_DOWN">
+            <button class="hw-btn quad-btn bottom-right" title="Next page" data-hwkey="PAGE_DOWN">
               <svg viewBox="0 0 24 24" class="icon-fill"><path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"/></svg>
             </button>
           </div>
@@ -223,7 +223,7 @@
 
         <!-- ZONE 3: media controls -->
         <div class="remote-zone-container remote-zone-3">
-          <button class="hw-btn" title="Muet" data-hwkey="MUTE">
+          <button class="hw-btn" title="Mute" data-hwkey="MUTE">
             <svg viewBox="0 0 24 24">
               <path d="M3 9h4l5-5v16l-5-5H3V9z" class="icon-stroke" /><path d="M16.59 12L14 9.41 15.41 8 18 10.59 20.59 8 22 9.41 19.41 12 22 14.59 20.59 16 18 13.41 15.41 16 14 14.59 16.59 12z" class="icon-fill" />
             </svg>
@@ -234,25 +234,25 @@
           <button class="hw-btn" title="Menu" data-hwkey="MAIN">
             <svg viewBox="0 0 24 24" class="icon-fill"><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
           </button>
-          <button class="hw-btn" title="Retour rapide" data-hwkey="REWIND">
+          <button class="hw-btn" title="Rewind" data-hwkey="REWIND">
             <svg viewBox="0 0 24 24" class="icon-stroke">
               <polygon points="11 18 3.5 12 11 6" />
               <polygon points="20.5 18 13 12 20.5 6" />
             </svg>
           </button>
-          <button class="hw-btn btn-play-pause" title="Lecture / Pause" data-hwkey="PLAY">
+          <button class="hw-btn btn-play-pause" title="Play / Pause" data-hwkey="PLAY">
             <svg viewBox="0 0 24 24">
               <polygon points="2 3 13 12 2 21" class="icon-stroke" />
               <rect x="16" y="4" width="2" height="16" rx="0.5" class="icon-fill" />
               <rect x="21" y="4" width="2" height="16" rx="0.5" class="icon-fill" />
             </svg>
           </button>
-          <button class="hw-btn" title="Arrêt" data-hwkey="STOP">
+          <button class="hw-btn" title="Stop" data-hwkey="STOP">
             <svg viewBox="0 0 24 24" class="icon-stroke">
               <rect x="6" y="6" width="12" height="12" rx="1" />
             </svg>
           </button>
-          <button class="hw-btn" title="Avance rapide" data-hwkey="FASTFORWARD">
+          <button class="hw-btn" title="Fast-forward" data-hwkey="FASTFORWARD">
             <svg viewBox="0 0 24 24" class="icon-stroke">
               <polygon points="13 18 20.5 12 13 6" />
               <polygon points="3.5 18 11 12 3.5 6" />
@@ -403,6 +403,6 @@
 <script src="js/export.js"></script>
 <script src="js/preview.js"></script>
 <script src="js/device.js"></script>
-<script>initEditor(); loadStableBadge();</script>
+<script>applyUiI18n(); initEditor(); loadStableBadge();</script>
 </body>
 </html>

--- a/docs/js/hotkeys.js
+++ b/docs/js/hotkeys.js
@@ -342,6 +342,58 @@ function addHotkey() {
 
 // ---- Release badges (official + beta) --------------------------------------
 
+const RELEASE_STRINGS = {
+  en: {
+    loading: 'Loading…',
+    stableUnavailable: 'Official release unavailable',
+    betaUnavailable: 'Beta unavailable',
+    downloadApk: 'download the APK',
+    installToDevice: 'Install on this device',
+    installing: 'Installing…',
+    installStarted: 'Install launched on the remote.',
+    installFailed: 'Install failed: ',
+    alsoBeta: 'Also the beta (dev)'
+  },
+  fr: {
+    loading: 'Chargement…',
+    stableUnavailable: 'Version officielle indisponible',
+    betaUnavailable: 'Bêta indisponible',
+    downloadApk: "télécharger l'APK",
+    installToDevice: 'Installer sur cet appareil',
+    installing: 'Installation…',
+    installStarted: 'Installation lancée sur la télécommande.',
+    installFailed: "Échec de l'installation : ",
+    alsoBeta: 'Aussi la bêta (dev)'
+  }
+};
+
+const HW_KEY_TITLES = {
+  en: {
+    BACK: 'Back', HOME: 'Home', POWER: 'Power', VOLUME_UP: 'Volume +',
+    PAGE_UP: 'Previous page', VOLUME_DOWN: 'Volume -', PAGE_DOWN: 'Next page',
+    MUTE: 'Mute', VOICE: 'Microphone', MAIN: 'Menu', REWIND: 'Rewind',
+    PLAY: 'Play / Pause', STOP: 'Stop', FASTFORWARD: 'Fast-forward'
+  },
+  fr: {
+    BACK: 'Retour', HOME: 'Accueil', POWER: 'Alimentation', VOLUME_UP: 'Volume +',
+    PAGE_UP: 'Page précédente', VOLUME_DOWN: 'Volume -', PAGE_DOWN: 'Page suivante',
+    MUTE: 'Muet', VOICE: 'Microphone', MAIN: 'Menu', REWIND: 'Retour rapide',
+    PLAY: 'Lecture / Pause', STOP: 'Arrêt', FASTFORWARD: 'Avance rapide'
+  }
+};
+
+const uiLang = ((navigator.language || 'en').split('-')[0]).startsWith('fr') ? 'fr' : 'en';
+const t = (key) => RELEASE_STRINGS[uiLang][key];
+
+function applyUiI18n() {
+  const betaLabel = document.getElementById('betaToggleLabel');
+  if (betaLabel) betaLabel.textContent = t('alsoBeta');
+  document.querySelectorAll('button[data-hwkey]').forEach(btn => {
+    const title = HW_KEY_TITLES[uiLang][btn.dataset.hwkey];
+    if (title) btn.title = title;
+  });
+}
+
 async function fetchReleaseBadge(url, icon) {
   try {
     const res = await fetch(url);
@@ -349,7 +401,7 @@ async function fetchReleaseBadge(url, icon) {
     const data = await res.json();
     const asset = (data.assets || []).find(a => a.name.endsWith('.apk'));
     return `${icon} ${data.name || data.tag_name}` +
-      (asset ? ` — <a href="${asset.browser_download_url}">télécharger l'APK</a>` : '');
+      (asset ? ` — <a href="${asset.browser_download_url}">${t('downloadApk')}</a>` : '');
   } catch (e) {
     console.log('Release fetch failed', e);
     return null;
@@ -359,24 +411,24 @@ async function fetchReleaseBadge(url, icon) {
 async function loadStableBadge() {
   const badge = document.getElementById('stableBadge');
   if (!badge) return;
-  badge.textContent = 'Chargement…';
+  badge.textContent = t('loading');
   const html = await fetchReleaseBadge(
     'https://api.github.com/repos/dckiller51/astrion-custom-dashboard/releases/latest', '✅'
   );
-  badge.innerHTML = html || 'Version officielle indisponible';
+  badge.innerHTML = html || t('stableUnavailable');
 }
 
 async function toggleBetaBadge() {
   const on = document.getElementById('betaToggle').checked;
   const badge = document.getElementById('betaBadge');
   if (!on) { badge.style.display = 'none'; return; }
-  badge.textContent = 'Chargement…';
+  badge.textContent = t('loading');
   badge.style.display = 'inline-block';
   const html = await fetchReleaseBadge(
     'https://api.github.com/repos/dckiller51/astrion-custom-dashboard/releases/tags/dev-latest', '🧪'
   );
   if (!html) {
-    badge.innerHTML = 'Bêta indisponible';
+    badge.innerHTML = t('betaUnavailable');
     return;
   }
   // In device mode (opened from the remote's own :8080), a real one-click
@@ -387,7 +439,7 @@ async function toggleBetaBadge() {
   // plain download link from fetchReleaseBadge stays as the fallback.
   if (typeof deviceModeAvailable !== 'undefined' && deviceModeAvailable) {
     const label = html.replace(/ — <a[^>]*>.*?<\/a>/, '');
-    badge.innerHTML = `${label} — <button type="button" onclick="installBetaUpdate(this)" style="padding:4px 10px;font-size:0.8rem">Installer sur cet appareil</button>`;
+    badge.innerHTML = `${label} — <button type="button" onclick="installBetaUpdate(this)" style="padding:4px 10px;font-size:0.8rem">${t('installToDevice')}</button>`;
   } else {
     badge.innerHTML = html;
   }
@@ -395,15 +447,15 @@ async function toggleBetaBadge() {
 
 async function installBetaUpdate(btn) {
   const original = btn.textContent;
-  btn.textContent = 'Installation…';
+  btn.textContent = t('installing');
   btn.disabled = true;
   try {
     const res = await fetch('/install-beta-update', { method: 'POST' });
     const text = await res.text();
     if (!res.ok) throw new Error(text || ('HTTP ' + res.status));
-    showToast('Installation lancée sur la télécommande.');
+    showToast(t('installStarted'));
   } catch (e) {
-    showToast('Échec de l\'installation : ' + e.message, 'error');
+    showToast(t('installFailed') + e.message, 'error');
     btn.textContent = original;
     btn.disabled = false;
   }


### PR DESCRIPTION
Settings pulldown's update row was hardcoded French ("Bêta disponible : dev-latest"), visible on English-locale devices. The audit for it surfaced a longer list of hardcoded strings, all now resource-backed:

- SettingsMenu: update row (beta + stable), local-config line, and the HA status detail (raw enum name before) use string resources; update row moved to a private UpdateRow composable
- Dashboard: connection banner (Connecting / Auth failed / Error / Disconnected) and the unknown-card message
- Cards: MediaBrowser (title, timeout/error, empty state), Plex card + detail dialog (loading, library, "This season", episode label, Play), Plex library dialog (loading, no items), media player dialog (Browse, toggle), select + source select empty states, vacuum name/map fallbacks
- Builder (docs/ and the assets mirror kept in sync): the release-badge feature shipped French-only (télécharger l'APK, Bêta indisponible, Installer sur cet appareil) — it now uses a small en/fr string table keyed on navigator.language, English default; the 11 hardware-key tooltips were a French/English mix, same treatment; fixes "Page precedente" along the way

28 new strings in values/ + values-fr/. ktlint, detekt, lint and unit tests green; installed and verified on the HA100 (locale en-US).